### PR TITLE
testing: response utils now allow other content-types

### DIFF
--- a/testing/response.go
+++ b/testing/response.go
@@ -11,38 +11,108 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-
 package testing
 
 import (
 	"encoding/json"
 	"github.com/ant0ine/go-json-rest/rest/test"
 	"github.com/stretchr/testify/assert"
+	"mime"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
-type JSONResponseParams struct {
-	OutputStatus     int
-	OutputBodyObject interface{}
-	OutputHeaders    map[string]string
+func CheckResponse(t *testing.T, want ResponseChecker, have *test.Recorded) {
+	want.CheckStatus(t, have)
+	want.CheckHeaders(t, have)
+	want.CheckContentType(t, have)
+	want.CheckBody(t, have)
 }
 
-func CheckRecordedResponse(t *testing.T, recorded *test.Recorded, params JSONResponseParams) {
+// ResponseChecker is a generic response checker, regardless of content-type.
+type ResponseChecker interface {
+	CheckStatus(t *testing.T, recorded *test.Recorded)
+	CheckHeaders(t *testing.T, recorded *test.Recorded)
+	CheckContentType(t *testing.T, recorded *test.Recorded)
+	CheckBody(t *testing.T, recorded *test.Recorded)
+}
 
-	recorded.CodeIs(params.OutputStatus)
-	recorded.ContentTypeIsJson()
+// BaseResponse is used for testing any response with a selected content type.
+// Implements ResponseChecker, provides base methods for common tests.
+type BaseResponse struct {
+	Status      int
+	ContentType string
+	Headers     map[string]string
+	Body        interface{}
+}
 
-	if params.OutputBodyObject != nil {
-		assert.NotEmpty(t, recorded.Recorder.Body.String())
+//
+func (b *BaseResponse) CheckStatus(t *testing.T, recorded *test.Recorded) {
+	recorded.CodeIs(b.Status)
+}
 
-		expectedJSON, err := json.Marshal(params.OutputBodyObject)
-		assert.NoError(t, err)
-		assert.JSONEq(t, string(expectedJSON), recorded.Recorder.Body.String())
-	} else {
-		assert.Empty(t, recorded.Recorder.Body.String())
+//
+func (b *BaseResponse) CheckContentType(t *testing.T, recorded *httptest.ResponseRecorder) {
+	mediaType, params, _ := mime.ParseMediaType(recorded.HeaderMap.Get("Content-Type"))
+	charset := params["charset"]
+
+	if mediaType != b.ContentType {
+		t.Errorf(
+			"Content-Type media type: %s expected, got: %s",
+			b.ContentType,
+			mediaType,
+		)
 	}
 
-	for name, value := range params.OutputHeaders {
+	if charset != "" && strings.ToUpper(charset) != "UTF-8" {
+		t.Errorf(
+			"Content-Type charset: must be empty or UTF-8, got: %s",
+			charset,
+		)
+	}
+}
+
+//
+func (b *BaseResponse) CheckHeaders(t *testing.T, recorded *test.Recorded) {
+	for name, value := range b.Headers {
 		assert.Equal(t, value, recorded.Recorder.HeaderMap.Get(name))
+	}
+}
+
+//
+func (b *BaseResponse) CheckBody(t *testing.T, recorded *test.Recorded) {
+	if b.Body != nil {
+		recorded.BodyIs(b.Body.(string))
+	}
+}
+
+// JSONResponse is used for testing 'application/json' responses.
+// Embeds the BaseResponse (implements ResponseChecker), and overrides relevant methods.
+type JSONResponse struct {
+	BaseResponse
+}
+
+//
+func NewJSONResponse(status int, contenttype string, headers map[string]string, body interface{}) *JSONResponse {
+	return &JSONResponse{
+		BaseResponse: BaseResponse{
+			Status:      status,
+			ContentType: contenttype,
+			Headers:     headers,
+			Body:        body,
+		},
+	}
+}
+
+//
+func (j *JSONResponse) CheckBody(t *testing.T, recorded *test.Recorded) {
+	if j.Body != nil {
+		assert.NotEmpty(t, recorded.Recorder.Body.String())
+		expected, err := json.Marshal(j.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, string(expected), recorded.Recorder.Body.String())
+	} else {
+		assert.Empty(t, recorded.Recorder.Body.String())
 	}
 }


### PR DESCRIPTION
how it works:
- the CheckResponse accepts a ResponseChecker interface, delegates checking
  the body, status, etc.
- different implementations of ResponseChecker can provide their own checking logic
- BaseResponse is a checker for 'any' content-type, and provides common funcs
  for checking status, headers
- JSONResponse implements json unmarshalling for checking the body

Issues: MEN-796

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>