### PR TITLE
mongo/migrate: skip migrations if target version is lower

### DIFF
--- a/mongo/migrate/migrator_simple.go
+++ b/mongo/migrate/migrator_simple.go
@@ -68,34 +68,37 @@ func (m *SimpleMigrator) Apply(ctx context.Context, target Version, migrations [
 
 	// try to apply migrations
 	for _, migration := range migrations {
-		if VersionIsLess(last, migration.Version()) {
+		mv := migration.Version()
+		if VersionIsLess(target, mv) {
+			l.Warnf("migration to version %s skipped, target version %s is lower",
+				mv, target)
+		} else if VersionIsLess(last, mv) {
 			// log, migration applied
 			l.Infof("applying migration from version %s to %s",
-				last, migration.Version())
+				last, mv)
 
 			// apply migration
 			if err := migration.Up(last); err != nil {
 				l.Errorf("migration from %s to %s failed: %s",
-					last, migration.Version(), err)
+					last, mv, err)
 
 				// migration from last to migration.Version() failed: err
 				return errors.Wrapf(err,
 					"failed to apply migration from %s to %s",
-					last, migration.Version())
+					last, mv)
 			}
 
-			if err := UpdateMigrationInfo(migration.Version(),
-				m.Session, m.Db); err != nil {
+			if err := UpdateMigrationInfo(mv, m.Session, m.Db); err != nil {
 
 				return errors.Wrapf(err,
 					"failed to record migration from %s to %s",
-					last, migration.Version())
+					last, mv)
 
 			}
-			last = migration.Version()
+			last = mv
 		} else {
 			// log migration already applied
-			l.Infof("migration to version %s skipped", migration.Version())
+			l.Infof("migration to version %s skipped", mv)
 		}
 	}
 

--- a/mongo/migrate/migrator_simple_test.go
+++ b/mongo/migrate/migrator_simple_test.go
@@ -92,6 +92,16 @@ func TestSimpleMigratorApply(t *testing.T) {
 				makeMigration(MakeVersion(1, 1, 0), MakeVersion(1, 0, 1), nil),
 			},
 		},
+		"ok - migration to lower": {
+			InputMigrations: nil,
+			InputVersion:    MakeVersion(0, 1, 0),
+			OutputVersion:   MakeVersion(0, 1, 0),
+
+			Migrators: []Migration{
+				makeMigration(MakeVersion(1, 0, 1), MakeVersion(0, 0, 0), nil),
+				makeMigration(MakeVersion(1, 1, 0), MakeVersion(1, 0, 1), nil),
+			},
+		},
 		"err - failed migration": {
 			InputMigrations: []MigrationEntry{
 				{


### PR DESCRIPTION
Support a weird scenario when target version for migrations is lower than the
actual migrations. In this case, we skip the migration and log a warning.

@mendersoftware/rndity @maciejmrowiec 