### PR TITLE
context/httpheader: util for keeping selected HTTP headers in request…

### DIFF
--- a/context/httpheader/header.go
+++ b/context/httpheader/header.go
@@ -1,0 +1,63 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package httpheader
+
+import (
+	"context"
+	"net/http"
+)
+
+const (
+	hdrKeyPrefix = "github.com/mendersoftware/deviceadm/context/httpheader."
+)
+
+func makeKeyName(hdr string) string {
+	return hdrKeyPrefix + hdr
+}
+
+// WithContext stores HTTP headers from `hdrs` which listed in `which` in a
+// context and returns the new context (ctx becomes the parent of newly created
+// context). Headers care provided as http.Header. Headers that are unset in
+// `hdrs` are skipped. Empty header names are skipped as well. Headers are
+// stored using httpheader package specific key namespace.
+func WithContext(ctx context.Context, hdrs http.Header, which ...string) context.Context {
+	if hdrs == nil || len(hdrs) == 0 {
+		return ctx
+	}
+	if len(which) == 0 {
+		return ctx
+	}
+
+	for _, h := range which {
+		if h == "" {
+			continue
+		}
+		hv := hdrs.Get(h)
+		if hv == "" {
+			continue
+		}
+		ctx = context.WithValue(ctx, makeKeyName(h), hdrs.Get(h))
+	}
+	return ctx
+}
+
+// FromContext extracts httpheader header and returns a string. If header was
+// not set in the context, an empty string is returned.
+func FromContext(ctx context.Context, hdr string) string {
+	v, ok := ctx.Value(makeKeyName(hdr)).(string)
+	if !ok {
+		return ""
+	}
+	return v
+}

--- a/context/httpheader/header_test.go
+++ b/context/httpheader/header_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package httpheader
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHttpHeader(t *testing.T) {
+
+	ctxb := context.Background()
+	ctx := WithContext(ctxb, nil, "foo")
+	assert.Equal(t, ctxb, ctx)
+
+	ctx = WithContext(ctxb, http.Header{}, "foo")
+	assert.Equal(t, ctxb, ctx)
+
+	ctx = WithContext(ctxb,
+		http.Header{
+			"Authorization":     []string{"foo"},
+			"X-Mender-Identity": []string{"barbar"},
+		},
+		"Authorization", "Foobar", "X-Mender-Identity")
+	assert.NotNil(t, ctx)
+	assert.NotEqual(t, ctxb, ctx)
+
+	assert.Equal(t, "foo", FromContext(ctx, "Authorization"))
+	assert.Equal(t, "", FromContext(ctx, "Foobar"))
+	assert.Equal(t, "barbar", FromContext(ctx, "X-Mender-Identity"))
+}


### PR DESCRIPTION
… context

Importing package used in deviceadm. The package is needed for deviceauth. 

@mendersoftware/rndity @maciejmrowiec 