### PR TITLE
apiclient: generic http client for inter-service calls

### DIFF
--- a/apiclient/api_client.go
+++ b/apiclient/api_client.go
@@ -1,0 +1,56 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package apiclient
+
+import (
+	"net/http"
+
+	"github.com/mendersoftware/go-lib-micro/requestid"
+
+	ctxhttpheader "github.com/mendersoftware/go-lib-micro/context/httpheader"
+)
+
+// maybeSetHeader sets HTTP header `hdr` to value `val` if `val` is not empty or
+// the header is not yet set.
+func maybeSetHeader(hdrs http.Header, hdr string, val string) {
+	if val == "" {
+		return
+	}
+
+	if hdrs.Get(hdr) == "" {
+		hdrs.Add(hdr, val)
+	}
+}
+
+// HttpApi is an http.Client wrapper tailored to use with mender's APIs.
+type HttpApi struct {
+}
+
+// Do behaves similarly to http.Client.Do(), but will also automatically add
+// mender related headers, if these can be built based on request's context. The
+// headers are:
+// - X-Mender-RequestId - extracted with requestid.FromContext()
+// - Authorization - extracted with httpheader.FromContext()
+// If given header is already set, the value from context will not be used
+func (a *HttpApi) Do(r *http.Request) (*http.Response, error) {
+	client := &http.Client{}
+	ctx := r.Context()
+
+	maybeSetHeader(r.Header, requestid.RequestIdHeader,
+		requestid.FromContext(ctx))
+	maybeSetHeader(r.Header, "Authorization",
+		ctxhttpheader.FromContext(ctx, "Authorization"))
+
+	return client.Do(r)
+}

--- a/apiclient/api_client_test.go
+++ b/apiclient/api_client_test.go
@@ -1,0 +1,60 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package apiclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ctxhttpheader "github.com/mendersoftware/go-lib-micro/context/httpheader"
+	"github.com/mendersoftware/go-lib-micro/requestid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApiClient(t *testing.T) {
+
+	c := HttpApi{}
+
+	// request that came to test server
+	var inreq *http.Request
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inreq = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r, _ := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+	ctx := r.Context()
+	ctx = requestid.WithContext(ctx, "123-456")
+	ctx = ctxhttpheader.WithContext(ctx,
+		http.Header{
+			"Authorization":     []string{"Bearer of-bad-news"},
+			"X-My-First-Header": []string{"none"},
+			"No-Override":       []string{"override"},
+		},
+		"Authorization", "No-Override")
+
+	// make sure that the client will not override already-set headers
+	r.Header.Add("No-Override", "original")
+
+	_, err := c.Do(r.WithContext(ctx))
+	assert.NoError(t, err)
+
+	assert.NotNil(t, inreq)
+	assert.Equal(t, "Bearer of-bad-news", inreq.Header.Get("Authorization"))
+	assert.Equal(t, "123-456", inreq.Header.Get(requestid.RequestIdHeader))
+	assert.Equal(t, "original", inreq.Header.Get("No-Override"))
+}

--- a/apiclient/runner.go
+++ b/apiclient/runner.go
@@ -1,0 +1,22 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package apiclient
+
+import (
+	"net/http"
+)
+
+type HttpRunner interface {
+	Do(r *http.Request) (*http.Response, error)
+}


### PR DESCRIPTION
the HttpRunner interface mimics http.Client and its Do(...) method.
the HttpApi implementation adds some Mender-specific request headers
to each request, and is designed to be used for internal calls between
Mender services.

Issues: MEN-1068

Changelog: None

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@bboozzoo this implementation was lifted from your recent pull request do devauth, ping me if this needs further coordination

@maciejmrowiec @mendersoftware/rndity 