### PR TITLE
store/utils: DbForTenant helper

### DIFF
--- a/store/utils.go
+++ b/store/utils.go
@@ -29,3 +29,9 @@ func DbFromContext(ctx context.Context, origDbName string) string {
 		return origDbName
 	}
 }
+
+// DbForTenant generates database name using simply the tenant name and
+//the original db name
+func DbForTenant(tenantId, origDbName string) string {
+	return origDbName + "-" + tenantId
+}

--- a/store/utils_test.go
+++ b/store/utils_test.go
@@ -45,3 +45,8 @@ func TestDbFromContext(t *testing.T) {
 	db := DbFromContext(identity.WithContext(ctx, &id), "foo")
 	assert.Equal(t, db, "foo-bar")
 }
+
+func TestDbForTenant(t *testing.T) {
+	db := DbForTenant("tenant-id", "foo-db")
+	assert.Equal(t, db, "foo-db-tenant-id")
+}


### PR DESCRIPTION
analogous to DbFromContext, but works on the basis of just the tenant id.
it eliminates the need to create a context with a correct identity.Identity
when just the tenant id is directly available.

Issues: MEN-1312

Changelog: None

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>