### PR TITLE
utils supporting multitenant migrations

### DIFF
--- a/mongo/migrate/db.go
+++ b/mongo/migrate/db.go
@@ -16,6 +16,7 @@ package migrate
 import (
 	"time"
 
+	"github.com/mendersoftware/go-lib-micro/store"
 	"github.com/pkg/errors"
 	"gopkg.in/mgo.v2"
 )
@@ -63,4 +64,23 @@ func UpdateMigrationInfo(version Version, sess *mgo.Session, db string) error {
 	}
 
 	return nil
+}
+
+func GetTenantDbs(sess *mgo.Session, matcher store.TenantDbMatchFunc) ([]string, error) {
+	s := sess.Copy()
+	defer s.Close()
+
+	dbs, err := s.DatabaseNames()
+	if err != nil {
+		return nil, err
+	}
+
+	tenantDbs := []string{}
+	for _, db := range dbs {
+		if matcher(db) {
+			tenantDbs = append(tenantDbs, db)
+		}
+	}
+
+	return tenantDbs, err
 }

--- a/mongo/migrate/db_test.go
+++ b/mongo/migrate/db_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Mender Software AS
+// Copyright 2017 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/mongo/migrate/db_test.go
+++ b/mongo/migrate/db_test.go
@@ -1,0 +1,70 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package migrate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/mgo.v2/bson"
+
+	. "github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"github.com/mendersoftware/go-lib-micro/store"
+)
+
+func TestGetTenantDbs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestGetTenantDbs in short mode.")
+	}
+
+	baseDb := "servicename"
+	testCases := map[string]struct {
+		dbs []string
+	}{
+		"no tenant dbs": {
+			dbs: []string{},
+		},
+		"1 tenant db": {
+			dbs: []string{
+				baseDb + "-tenant1",
+			},
+		},
+		">1 tenant db": {
+			dbs: []string{
+				baseDb + "-tenant1",
+				baseDb + "-tenant2",
+				baseDb + "-tenant3",
+			},
+		},
+	}
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
+			db.Wipe()
+			session := db.Session()
+
+			// dummy insert on test dbs to create them
+			for _, db := range tc.dbs {
+				err := session.DB(db).C("foo").Insert(bson.M{"foo": "bar"})
+				assert.NoError(t, err)
+			}
+
+			res, err := GetTenantDbs(session, store.IsTenantDb(baseDb))
+			assert.NoError(t, err)
+			assert.Equal(t, tc.dbs, res)
+
+			session.Close()
+		})
+	}
+}

--- a/mongo/migrate/migrator_simple.go
+++ b/mongo/migrate/migrator_simple.go
@@ -15,13 +15,23 @@ package migrate
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/pkg/errors"
 	"gopkg.in/mgo.v2"
 
 	"github.com/mendersoftware/go-lib-micro/log"
 )
+
+var (
+	ErrNeedsMigration = "db needs migration"
+)
+
+func IsErrNeedsMigration(e error) bool {
+	return strings.HasPrefix(e.Error(), ErrNeedsMigration)
+}
 
 // SimpleMigratior applies migrations by comparing `Version` of migrations
 // passed to Apply() and already applied migrations. Only migrations that are of
@@ -32,17 +42,20 @@ import (
 //   migrations that will be applied: 1.0.3, 1.1.0
 //
 type SimpleMigrator struct {
-	Session *mgo.Session
-	Db      string
+	Session     *mgo.Session
+	Db          string
+	Automigrate bool
 }
 
-// Apply will apply migrations. After each successful migration a new migration
+// Apply will apply migrations, provided that Automigrate is on. After each successful migration a new migration
 // record will be added to DB with the version of migration that was just
 // applied. If a migration fails, Apply() returns an error and does not add a
 // migration record (so last migration that is recorded is N-1).
 //
 // Apply() will log some messages when running. Logger will be extracted from
 // context using go-lib-micro/log.LoggerContextKey as key.
+// If Automigrate is off, the migrator will just check if the DB is up-to-date, and return with ErrNeedsMigration otherwise.
+// Check for it with IsErrNeedsMigration.
 func (m *SimpleMigrator) Apply(ctx context.Context, target Version, migrations []Migration) error {
 	l := log.FromContext(ctx).F(log.Ctx{"db": m.Db})
 
@@ -65,6 +78,16 @@ func (m *SimpleMigrator) Apply(ctx context.Context, target Version, migrations [
 		})
 		// last version from already applied migrations
 		last = applied[len(applied)-1].Version
+	}
+
+	// if Automigrate is disabled - just check
+	// if the last applied migration is lower than the target one
+	if !m.Automigrate {
+		if VersionIsLess(last, target) {
+			return fmt.Errorf(ErrNeedsMigration+": %s has version %s, needs version %s", m.Db, last.String(), target.String())
+		} else {
+			return nil
+		}
 	}
 
 	// try to apply migrations

--- a/mongo/migrate/migrator_simple_test.go
+++ b/mongo/migrate/migrator_simple_test.go
@@ -39,6 +39,7 @@ func TestSimpleMigratorApply(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
+		Automigrate     bool
 		InputMigrations []MigrationEntry
 		InputVersion    Version
 
@@ -48,6 +49,7 @@ func TestSimpleMigratorApply(t *testing.T) {
 		OutputError   error
 	}{
 		"ok - empty state": {
+			Automigrate:     true,
 			InputMigrations: nil,
 			InputVersion:    MakeVersion(1, 0, 0),
 
@@ -55,6 +57,18 @@ func TestSimpleMigratorApply(t *testing.T) {
 		},
 
 		"ok - already has version": {
+			Automigrate: true,
+			InputMigrations: []MigrationEntry{
+				{
+					Version:   MakeVersion(1, 0, 0),
+					Timestamp: time.Now(),
+				},
+			},
+			InputVersion:  MakeVersion(1, 0, 0),
+			OutputVersion: MakeVersion(1, 0, 0),
+		},
+		"ok - already has version, no automigrate": {
+			Automigrate: false,
 			InputMigrations: []MigrationEntry{
 				{
 					Version:   MakeVersion(1, 0, 0),
@@ -65,6 +79,7 @@ func TestSimpleMigratorApply(t *testing.T) {
 			OutputVersion: MakeVersion(1, 0, 0),
 		},
 		"ok - add default target version": {
+			Automigrate: true,
 			InputMigrations: []MigrationEntry{
 				{
 					Version:   MakeVersion(1, 0, 0),
@@ -74,7 +89,20 @@ func TestSimpleMigratorApply(t *testing.T) {
 			InputVersion:  MakeVersion(1, 1, 0),
 			OutputVersion: MakeVersion(1, 1, 0),
 		},
+		"ok - add default target version, no automigrate": {
+			Automigrate: false,
+			InputMigrations: []MigrationEntry{
+				{
+					Version:   MakeVersion(1, 0, 0),
+					Timestamp: time.Now(),
+				},
+			},
+			InputVersion:  MakeVersion(1, 1, 0),
+			OutputVersion: MakeVersion(1, 0, 0),
+			OutputError:   errors.New("db needs migration: test has version 1.0.0, needs version 1.1.0"),
+		},
 		"ok - ran migrations": {
+			Automigrate: true,
 			InputMigrations: []MigrationEntry{
 				{
 					Version:   MakeVersion(1, 0, 0),
@@ -93,7 +121,29 @@ func TestSimpleMigratorApply(t *testing.T) {
 				makeMigration(MakeVersion(1, 1, 0), MakeVersion(1, 0, 1), nil),
 			},
 		},
+		"ok - ran migrations, no automigrate": {
+			Automigrate: false,
+			InputMigrations: []MigrationEntry{
+				{
+					Version:   MakeVersion(1, 0, 0),
+					Timestamp: time.Now(),
+				},
+				{
+					Version:   MakeVersion(1, 0, 1),
+					Timestamp: time.Now(),
+				},
+			},
+			InputVersion:  MakeVersion(1, 1, 0),
+			OutputVersion: MakeVersion(1, 0, 1),
+
+			Migrators: []Migration{
+				makeMigration(MakeVersion(1, 0, 1), MakeVersion(1, 0, 0), nil),
+				makeMigration(MakeVersion(1, 1, 0), MakeVersion(1, 0, 1), nil),
+			},
+			OutputError: errors.New("db needs migration: test has version 1.0.1, needs version 1.1.0"),
+		},
 		"ok - migration to lower": {
+			Automigrate:     true,
 			InputMigrations: nil,
 			InputVersion:    MakeVersion(0, 1, 0),
 			OutputVersion:   MakeVersion(0, 1, 0),
@@ -104,6 +154,7 @@ func TestSimpleMigratorApply(t *testing.T) {
 			},
 		},
 		"err - failed migration": {
+			Automigrate: true,
 			InputMigrations: []MigrationEntry{
 				{
 					Version:   MakeVersion(1, 0, 0),
@@ -138,7 +189,7 @@ func TestSimpleMigratorApply(t *testing.T) {
 			}
 
 			//test
-			m := &SimpleMigrator{Session: session, Db: "test"}
+			m := &SimpleMigrator{Session: session, Db: "test", Automigrate: tc.Automigrate}
 			err := m.Apply(context.Background(), tc.InputVersion, tc.Migrators)
 			if tc.OutputError != nil {
 				assert.Error(t, err)
@@ -159,4 +210,10 @@ func TestSimpleMigratorApply(t *testing.T) {
 			session.Close()
 		})
 	}
+}
+
+func TestErrNeedsMigration(t *testing.T) {
+	err := errors.New("db needs migration: mydbname has version 1.0.0, needs version 1.1.0")
+
+	assert.True(t, IsErrNeedsMigration(err))
 }

--- a/store/utils.go
+++ b/store/utils.go
@@ -15,6 +15,7 @@ package store
 
 import (
 	"context"
+	"strings"
 
 	"github.com/mendersoftware/go-lib-micro/identity"
 )
@@ -27,5 +28,14 @@ func DbFromContext(ctx context.Context, origDbName string) string {
 		return origDbName + "-" + identity.Tenant
 	} else {
 		return origDbName
+	}
+}
+
+type TenantDbMatchFunc func(name string) bool
+
+func IsTenantDb(baseDb string) TenantDbMatchFunc {
+	prefix := baseDb + "-"
+	return func(name string) bool {
+		return strings.HasPrefix(name, prefix)
 	}
 }

--- a/store/utils_test.go
+++ b/store/utils_test.go
@@ -45,3 +45,12 @@ func TestDbFromContext(t *testing.T) {
 	db := DbFromContext(identity.WithContext(ctx, &id), "foo")
 	assert.Equal(t, db, "foo-bar")
 }
+
+func TestIsTenantDb(t *testing.T) {
+	matcher := IsTenantDb("servicedb")
+
+	assert.True(t, matcher("servicedb-tenant1"))
+	assert.False(t, matcher("servicedb"))
+	assert.False(t, matcher("servicedbtenant1"))
+
+}


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-1243

- a simple low-level listing of tenant dbs according to conventions
- introduction of the idea of `automigrations` (as opposed to just checking db versions) into the migrator

note that even with multitenancy, the migrator works on a single db - the store will control iteration over tenant dbs.

@maciejmrowiec @mendersoftware/rndity 