### PR TITLE
mongo/migrate: make dummy migrator multitenancy-aware

### DIFF
--- a/mongo/migrate/migrator_dummy.go
+++ b/mongo/migrate/migrator_dummy.go
@@ -15,26 +15,53 @@ package migrate
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"gopkg.in/mgo.v2"
+
+	"github.com/mendersoftware/go-lib-micro/log"
 )
 
 // MigratorDummy does not actually apply migrations, just inserts the
 // target version into the db to mark the initial/current state.
 type DummyMigrator struct {
-	Session *mgo.Session
-	Db      string
+	Session     *mgo.Session
+	Db          string
+	Automigrate bool
 }
 
 // Apply makes MigratorDummy implement the Migrator interface.
 func (m *DummyMigrator) Apply(ctx context.Context, target Version, migrations []Migration) error {
+	l := log.FromContext(ctx).F(log.Ctx{"db": m.Db})
+
 	applied, err := GetMigrationInfo(m.Session, m.Db)
 	if err != nil {
 		return err
 	}
 
-	if len(applied) == 0 {
+	if len(applied) > 1 {
+		return errors.New("dummy migrator cannot apply migrations, more than 1 already applied")
+	}
+
+	last := Version{}
+	if len(applied) == 1 {
+		last = applied[0].Version
+	}
+
+	if !m.Automigrate {
+		if VersionIsLess(last, target) {
+			return fmt.Errorf(ErrNeedsMigration+": %s has version %s, needs version %s", m.Db, last.String(), target.String())
+		} else {
+			return nil
+		}
+	}
+
+	if VersionIsLess(last, target) {
+		l.Infof("applying migration from version %s to %s", last, target)
 		return UpdateMigrationInfo(target, m.Session, m.Db)
+	} else {
+		l.Infof("migration to version %s skipped", target)
 	}
 
 	return nil


### PR DESCRIPTION
needed e.g. by useradm.

Issues: MEN-1255

Changelog: None

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@maciejmrowiec @mendersoftware/rndity 