### PR TITLE
global: avoid use of basic types as context.Context keys

### DIFF
--- a/context/httpheader/header.go
+++ b/context/httpheader/header.go
@@ -18,12 +18,10 @@ import (
 	"net/http"
 )
 
-const (
-	hdrKeyPrefix = "github.com/mendersoftware/deviceadm/context/httpheader."
-)
+type headerKeyType string
 
-func makeKeyName(hdr string) string {
-	return hdrKeyPrefix + hdr
+func makeKeyName(hdr string) headerKeyType {
+	return headerKeyType(hdr)
 }
 
 // WithContext stores HTTP headers from `hdrs` which listed in `which` in a

--- a/context/httpheader/header_test.go
+++ b/context/httpheader/header_test.go
@@ -42,4 +42,6 @@ func TestHttpHeader(t *testing.T) {
 	assert.Equal(t, "foo", FromContext(ctx, "Authorization"))
 	assert.Equal(t, "", FromContext(ctx, "Foobar"))
 	assert.Equal(t, "barbar", FromContext(ctx, "X-Mender-Identity"))
+
+	assert.Nil(t, ctx.Value("X-Mender-Identity"))
 }

--- a/identity/token.go
+++ b/identity/token.go
@@ -22,10 +22,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	IdentityContextKey = "github.com/mendersoftware/go-lib-micro/identity.Identity"
-)
-
 // Token field names
 const (
 	subjectClaim = "sub"

--- a/identity/utils.go
+++ b/identity/utils.go
@@ -17,9 +17,15 @@ import (
 	"context"
 )
 
+type identityContextKeyType int
+
+const (
+	identityContextKey identityContextKeyType = 0
+)
+
 // FromContext extracts current identity from context.Context
 func FromContext(ctx context.Context) *Identity {
-	val := ctx.Value(IdentityContextKey)
+	val := ctx.Value(identityContextKey)
 	if v, ok := val.(*Identity); ok {
 		return v
 	}
@@ -28,5 +34,5 @@ func FromContext(ctx context.Context) *Identity {
 
 // WithContext adds identity to context `ctx` and returns the resulting context.
 func WithContext(ctx context.Context, identity *Identity) context.Context {
-	return context.WithValue(ctx, IdentityContextKey, identity)
+	return context.WithValue(ctx, identityContextKey, identity)
 }

--- a/identity/utils_test.go
+++ b/identity/utils_test.go
@@ -28,4 +28,8 @@ func TestContext(t *testing.T) {
 	}
 	assert.Empty(t, FromContext(context.Background()))
 	assert.Equal(t, &identity, FromContext(WithContext(context.Background(), &identity)))
+
+	ctx := WithContext(context.Background(), &identity)
+	// trying to fetch with same value but different type should fail
+	assert.Nil(t, ctx.Value(0))
 }

--- a/log/log.go
+++ b/log/log.go
@@ -44,8 +44,10 @@ var (
 	Log = logrus.New()
 )
 
+type loggerContextKeyType int
+
 const (
-	LoggerContextKey = "github.com/mendersoftware/go-lib-micro/log.Logger"
+	loggerContextKey loggerContextKeyType = 0
 )
 
 // ContextLogger interface for components which support
@@ -144,7 +146,7 @@ func (hook ContextHook) Fire(entry *logrus.Entry) error {
 // Logger is based on logrus.Entry, if logger instance from context is any of
 // logrus.Logger, logrus.Entry, necessary adaption will be applied.
 func FromContext(ctx context.Context) *Logger {
-	l := ctx.Value(LoggerContextKey)
+	l := ctx.Value(loggerContextKey)
 	if l == nil {
 		return New(Ctx{})
 	}
@@ -163,5 +165,5 @@ func FromContext(ctx context.Context) *Logger {
 
 // WithContext adds logger to context `ctx` and returns the resulting context.
 func WithContext(ctx context.Context, log *Logger) context.Context {
-	return context.WithValue(ctx, LoggerContextKey, log)
+	return context.WithValue(ctx, loggerContextKey, log)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -106,5 +106,7 @@ func TestFromWithContext(t *testing.T) {
 	assert.Len(t, ln2.Data, 0)
 
 	ctx = WithContext(context.Background(), l)
-	assert.NotNil(t, ctx.Value(LoggerContextKey))
+	assert.NotNil(t, ctx.Value(loggerContextKey))
+
+	assert.Nil(t, ctx.Value(0))
 }

--- a/requestid/utils.go
+++ b/requestid/utils.go
@@ -19,6 +19,12 @@ import (
 	"github.com/ant0ine/go-json-rest/rest"
 )
 
+type requestIdKeyType int
+
+const (
+	requestIdKey requestIdKeyType = 0
+)
+
 // GetReqId helper for retrieving current request Id
 func GetReqId(r *rest.Request) string {
 	reqid := r.Env[RequestIdHeader]
@@ -31,7 +37,7 @@ func GetReqId(r *rest.Request) string {
 
 // FromContext extracts current request Id from context.Context
 func FromContext(ctx context.Context) string {
-	val := ctx.Value(RequestIdHeader)
+	val := ctx.Value(requestIdKey)
 	if v, ok := val.(string); ok {
 		return v
 	}
@@ -40,5 +46,5 @@ func FromContext(ctx context.Context) string {
 
 // WithContext adds request to context `ctx` and returns the resulting context.
 func WithContext(ctx context.Context, reqid string) context.Context {
-	return context.WithValue(ctx, RequestIdHeader, reqid)
+	return context.WithValue(ctx, requestIdKey, reqid)
 }

--- a/requestid/utils_test.go
+++ b/requestid/utils_test.go
@@ -26,9 +26,7 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, "", FromContext(context.Background()))
 	assert.Equal(t, "foo",
 		FromContext(WithContext(context.Background(), "foo")))
-	// fallback to default string if someone packs the value into context
-	// themselves
-	assert.Equal(t, "",
-		FromContext(context.WithValue(context.Background(),
-			RequestIdHeader, 123)))
+
+	// make sure that the helpers are using private types
+	assert.Nil(t, WithContext(context.Background(), "foo").Value(0))
 }


### PR DESCRIPTION
The rationale behind this is that basic types are accessible everywhere, so it
is possible that someone may accidentally use the same value as the key and
overwrite existing Value in the context. A recommended solution for this is
using package private types. According to Go's equality rules:

  Interface values are comparable. Two interface values are equal if they have
  identical dynamic types and equal dynamic values or if both have value nil.

Since Key in context.Context is an interface{}, use of package private types
with either contstant non-nil value or value set at runtime will be sufficient.

@mendersoftware/rndity 