### PR TITLE
requestlog/requestid: stop using rest.Request.Env for keeping request logger and request ID

### DIFF
--- a/accesslog/middleware.go
+++ b/accesslog/middleware.go
@@ -54,7 +54,7 @@ func (mw *AccessLogMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFu
 		// call the handler
 		h(w, r)
 
-		logger := requestlog.GetRequestLogger(r.Env)
+		logger := requestlog.GetRequestLogger(r)
 		util := &accessLogUtil{w, r}
 
 		logger.Print(mw.executeTextTemplate(util))

--- a/context/middleware.go
+++ b/context/middleware.go
@@ -28,7 +28,7 @@ import (
 // accessed using log.FromContext(ctx).
 func RepackLoggerToContext(ctx context.Context, r *rest.Request) context.Context {
 	return log.WithContext(ctx,
-		requestlog.GetRequestLogger(r.Env))
+		requestlog.GetRequestLogger(r))
 }
 
 // RepackRequestIdToContext can be used to attach a request ID assigned by
@@ -39,7 +39,7 @@ func RepackRequestIdToContext(ctx context.Context, r *rest.Request) context.Cont
 		requestid.GetReqId(r))
 }
 
-// ContextUpdateFunc is a function that can update context ctx using data from
+// UpdateContextFunc is a function that can update context ctx using data from
 // rest.Request and return modified context.
 type UpdateContextFunc func(ctx context.Context, r *rest.Request) context.Context
 

--- a/requestid/middleware.go
+++ b/requestid/middleware.go
@@ -38,11 +38,10 @@ func (mw *RequestIdMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFu
 		r.Env[RequestIdHeader] = reqId
 
 		// enrich log context
-		logger := r.Env[requestlog.ReqLog]
+		logger := requestlog.GetRequestLogger(r)
 		if logger != nil {
-			logger := logger.(*log.Logger)
 			logger = logger.F(log.Ctx{"request_id": reqId})
-			r.Env[requestlog.ReqLog] = logger
+			r = requestlog.SetRequestLogger(r, logger)
 		}
 
 		//return the reuqest ID in response too, the client can log it


### PR DESCRIPTION
Request ID and associated logger will be kept in request context instead.


@mendersoftware/rndity 