### PR TITLE
store/utils: get db name for tenant

### DIFF
--- a/store/utils.go
+++ b/store/utils.go
@@ -24,11 +24,12 @@ import (
 // from context and original database name
 func DbFromContext(ctx context.Context, origDbName string) string {
 	identity := identity.FromContext(ctx)
-	if identity != nil && identity.Tenant != "" {
-		return origDbName + "-" + identity.Tenant
-	} else {
-		return origDbName
+	tenant := ""
+	if identity != nil {
+		tenant = identity.Tenant
 	}
+
+	return DbNameForTenant(tenant, origDbName)
 }
 
 type TenantDbMatchFunc func(name string) bool

--- a/store/utils.go
+++ b/store/utils.go
@@ -51,3 +51,11 @@ func TenantFromDbName(dbName string, baseDb string) string {
 	}
 	return noBase
 }
+
+// DbNameForTenant composes tenant's db name.
+func DbNameForTenant(tenantId string, baseDb string) string {
+	if tenantId == "" {
+		return baseDb
+	}
+	return baseDb + "-" + tenantId
+}

--- a/store/utils_test.go
+++ b/store/utils_test.go
@@ -63,3 +63,8 @@ func TestTenantFromDbName(t *testing.T) {
 	assert.Equal(t, "198273913adsjhakdh",
 		TenantFromDbName("123__--afff-198273913adsjhakdh", "123__--afff"))
 }
+
+func TestDbNameForTenant(t *testing.T) {
+	assert.Equal(t, "basedb-tenant1", DbNameForTenant("tenant1", "basedb"))
+	assert.Equal(t, "basedb", DbNameForTenant("", "basedb"))
+}


### PR DESCRIPTION
changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

small util that will come in handy in `deployments` migrations.

@mendersoftware/rndity 