### PR TITLE
rest_utils: helpers for parsing api error responses

### DIFF
--- a/rest_utils/api_error.go
+++ b/rest_utils/api_error.go
@@ -1,0 +1,45 @@
+// Copyright 2017 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package rest_utils
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// ApiError wraps errors returned by our APIs
+type ApiError struct {
+	Err   string `json:"error"`
+	ReqId string `json:"request_id"`
+}
+
+func (ae *ApiError) Error() string {
+	return ae.Err
+}
+
+func IsApiError(e error) bool {
+	_, ok := e.(*ApiError)
+	return ok
+}
+
+func ParseApiError(source io.Reader) error {
+	jd := json.NewDecoder(source)
+
+	var aerr ApiError
+	if err := jd.Decode(&aerr); err != nil {
+		return err
+	}
+
+	return &aerr
+}

--- a/rest_utils/api_error_test.go
+++ b/rest_utils/api_error_test.go
@@ -1,0 +1,38 @@
+// Copyright 2017 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package rest_utils
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseApiErrOk(t *testing.T) {
+	body := `{"error": "some error message", "request_id":"12345"}`
+
+	err := ParseApiError(bytes.NewBufferString(body))
+
+	assert.True(t, IsApiError(err))
+	assert.Equal(t, &ApiError{Err: "some error message", ReqId: "12345"}, err)
+}
+
+func TestParseApiErrInvalid(t *testing.T) {
+	body := `asdf`
+
+	err := ParseApiError(bytes.NewBufferString(body))
+
+	assert.False(t, IsApiError(err))
+}


### PR DESCRIPTION
will be useful whenever we need to extract info from a downstream
service's error response.

current use case is propagating error messages re dev count limits
from devauth to the user via devadm.

changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@mendersoftware/rndity @maciejmrowiec 