### PR TITLE
Rename all `session` references to `client`

### DIFF
--- a/mongo/migrate/db_test.go
+++ b/mongo/migrate/db_test.go
@@ -52,17 +52,17 @@ func TestGetTenantDbs(t *testing.T) {
 		tc := testCases[name]
 		t.Run(name, func(t *testing.T) {
 			db.Wipe()
-			session := db.Session()
+			client := db.Client()
 
 			// dummy insert on test dbs to create them
 			for _, dbname := range tc.dbs {
-				_, err := session.Database(dbname).
+				_, err := client.Database(dbname).
 					Collection("foo").
 					InsertOne(db.CTX(), bson.M{"foo": "bar"})
 				assert.NoError(t, err)
 			}
 
-			res, err := GetTenantDbs(db.CTX(), session, store.IsTenantDb(baseDb))
+			res, err := GetTenantDbs(db.CTX(), client, store.IsTenantDb(baseDb))
 			assert.NoError(t, err)
 			assert.Equal(t, tc.dbs, res)
 		})

--- a/mongo/migrate/migrator_dummy.go
+++ b/mongo/migrate/migrator_dummy.go
@@ -26,7 +26,7 @@ import (
 // MigratorDummy does not actually apply migrations, just inserts the
 // target version into the db to mark the initial/current state.
 type DummyMigrator struct {
-	Session     *mongo.Client
+	Client     *mongo.Client
 	Db          string
 	Automigrate bool
 }
@@ -35,7 +35,7 @@ type DummyMigrator struct {
 func (m *DummyMigrator) Apply(ctx context.Context, target Version, migrations []Migration) error {
 	l := log.FromContext(ctx).F(log.Ctx{"db": m.Db})
 
-	applied, err := GetMigrationInfo(ctx, m.Session, m.Db)
+	applied, err := GetMigrationInfo(ctx, m.Client, m.Db)
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func (m *DummyMigrator) Apply(ctx context.Context, target Version, migrations []
 
 	if VersionIsLess(last, target) {
 		l.Infof("applying migration from version %s to %s", last, target)
-		return UpdateMigrationInfo(ctx, target, m.Session, m.Db)
+		return UpdateMigrationInfo(ctx, target, m.Client, m.Db)
 	} else {
 		l.Infof("migration to version %s skipped", target)
 	}

--- a/mongo/migrate/migrator_dummy_test.go
+++ b/mongo/migrate/migrator_dummy_test.go
@@ -85,21 +85,21 @@ func TestDummyMigratorApply(t *testing.T) {
 
 		//setup
 		db.Wipe()
-		session := db.Session()
+		client := db.Client()
 		for _, m := range tc.InputMigrations {
-			_, err := session.Database("test").
+			_, err := client.Database("test").
 				Collection(DbMigrationsColl).
 				InsertOne(db.CTX(), m)
 			assert.NoError(t, err)
 		}
 
 		//test
-		m := &DummyMigrator{Session: session, Db: "test", Automigrate: tc.Automigrate}
+		m := &DummyMigrator{Client: client, Db: "test", Automigrate: tc.Automigrate}
 		m.Apply(context.Background(), tc.InputVersion, nil)
 
 		//verify
 		var out []MigrationEntry
-		cursor, _ := session.Database("test").
+		cursor, _ := client.Database("test").
 			Collection(DbMigrationsColl).
 			Find(db.CTX(), bson.M{})
 

--- a/mongo/migrate/migrator_simple.go
+++ b/mongo/migrate/migrator_simple.go
@@ -42,7 +42,7 @@ func IsErrNeedsMigration(e error) bool {
 //   migrations that will be applied: 1.0.3, 1.1.0
 //
 type SimpleMigrator struct {
-	Session     *mongo.Client
+	Client      *mongo.Client
 	Db          string
 	Automigrate bool
 }
@@ -63,7 +63,7 @@ func (m *SimpleMigrator) Apply(ctx context.Context, target Version, migrations [
 		return VersionIsLess(migrations[i].Version(), migrations[j].Version())
 	})
 
-	applied, err := GetMigrationInfo(ctx, m.Session, m.Db)
+	applied, err := GetMigrationInfo(ctx, m.Client, m.Db)
 	if err != nil {
 		return errors.Wrap(err, "failed to list applied migrations")
 	}
@@ -112,7 +112,7 @@ func (m *SimpleMigrator) Apply(ctx context.Context, target Version, migrations [
 					last, mv)
 			}
 
-			if err := UpdateMigrationInfo(ctx, mv, m.Session, m.Db); err != nil {
+			if err := UpdateMigrationInfo(ctx, mv, m.Client, m.Db); err != nil {
 
 				return errors.Wrapf(err,
 					"failed to record migration from %s to %s",
@@ -131,7 +131,7 @@ func (m *SimpleMigrator) Apply(ctx context.Context, target Version, migrations [
 		l.Warnf("last migration to version %s did not produce target version %s",
 			last, target)
 		// record DB version anyways
-		if err := UpdateMigrationInfo(ctx, target, m.Session, m.Db); err != nil {
+		if err := UpdateMigrationInfo(ctx, target, m.Client, m.Db); err != nil {
 			return errors.Wrapf(err,
 				"failed to record migration from %s to %s",
 				last, target)

--- a/mongo/migrate/migrator_simple_test.go
+++ b/mongo/migrate/migrator_simple_test.go
@@ -182,16 +182,16 @@ func TestSimpleMigratorApply(t *testing.T) {
 
 			//setup
 			db.Wipe()
-			session := db.Session()
+			client := db.Client()
 			for i := range tc.InputMigrations {
-				_, err := session.Database("test").
+				_, err := client.Database("test").
 					Collection(DbMigrationsColl).
 					InsertOne(db.CTX(), tc.InputMigrations[i])
 				assert.NoError(t, err)
 			}
 
 			//test
-			m := &SimpleMigrator{Session: session, Db: "test", Automigrate: tc.Automigrate}
+			m := &SimpleMigrator{Client: client, Db: "test", Automigrate: tc.Automigrate}
 			err := m.Apply(context.Background(), tc.InputVersion, tc.Migrators)
 			if tc.OutputError != nil {
 				assert.Error(t, err)
@@ -202,7 +202,7 @@ func TestSimpleMigratorApply(t *testing.T) {
 
 			//verify
 			var out []MigrationEntry
-			cursor, _ := session.Database("test").
+			cursor, _ := client.Database("test").
 				Collection(DbMigrationsColl).
 				Find(db.CTX(), bson.M{})
 

--- a/mongo/testing/db.go
+++ b/mongo/testing/db.go
@@ -25,7 +25,7 @@ import (
 // TestDBRunner exports selected calls of dbtest.DBServer API, just the ones
 // that are useful in tests.
 type TestDBRunner interface {
-	Session() *mongo.Client
+	Client() *mongo.Client
 	Wipe()
 	CTX() context.Context
 }


### PR DESCRIPTION
To comply with the new mongodb driver, the client construct is used in
all cases as session was previously used. The renaming is done in order
not to confuse the term with the session construct of mongodb.

changelog: none

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>