### PR TITLE
Fix unit tests coverage reports collection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,13 +52,14 @@ test:unit:
     # Test packages pararell (xargs -P)
     - go list ./... | grep -v vendor | xargs -n1 -I {} -P 4 go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} || exit $?
 
-    # Collect coverage report
-    - cp coverage.txt $CI_PROJECT_DIR/
+    # Collect coverage reports
+    - mkdir -p tests/unit-coverage && find . -name 'coverage.txt' -exec cp --parents {} ./tests/unit-coverage \;
+    - tar -cvf $CI_PROJECT_DIR/unit-coverage.tar tests/unit-coverage
 
   artifacts:
     expire_in: 2w
     paths:
-      - coverage.txt
+      - unit-coverage.tar
 
 publish:tests:
   image: alpine
@@ -68,4 +69,5 @@ publish:tests:
   dependencies:
     - test:unit
   script:
-    - bash -c "bash <(curl -s https://codecov.io/bash) -Z"
+    - tar -xvf unit-coverage.tar
+    - bash -c "bash <(curl -s https://codecov.io/bash) -Z -s ./tests/unit-coverage"


### PR DESCRIPTION
Fix unit tests coverage reports collection

The way we execute `go test` it will create multiple coverage.txt across
subfolders.

This is actually the same design used in many other backend repos.