### PR TITLE
identity: handle "mender.plan" claim in the identity middleware

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 Northern.tech AS
+Copyright 2020 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,5 +1,5 @@
 # Apache 2.0 license.
-c1452ea0feb52f2e6e6aaba33ae0d558626ba8c69ad7cb6866f2d4fbb7a711dc  LICENSE
+d5a55eaa82e2c109b8bcadfa66139497511b80d665668264f155b5a45086b086  LICENSE
 409777def58db7e220011d266bb963259b5d45fc490e58a0d97acad2b591609a  vendor/github.com/ant0ine/go-json-rest/LICENSE
 1b93a317849ee09d3d7e4f1d20c2b78ddb230b4becb12d7c224c927b9d470251  vendor/github.com/davecgh/go-spew/LICENSE
 2eb550be6801c1ea434feba53bf6d12e7c71c90253e0a9de4a4f46cf88b56477  vendor/github.com/pmezard/go-difflib/LICENSE

--- a/identity/middleware.go
+++ b/identity/middleware.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -60,6 +60,10 @@ func (mw *IdentityMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFun
 
 				if identity.Tenant != "" {
 					logCtx["tenant_id"] = identity.Tenant
+				}
+
+				if identity.Plan != "" {
+					logCtx["plan"] = identity.Plan
 				}
 
 				l = l.F(logCtx)

--- a/identity/middleware_test.go
+++ b/identity/middleware_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ func TestIdentityMiddlewareNoSubject(t *testing.T) {
 	handler := api.MakeHandler()
 
 	req := test.MakeSimpleRequest("GET", "http://localhost/", nil)
-	rawclaims := makeClaimsPart(identity.Subject, identity.Tenant)
+	rawclaims := makeClaimsPart(identity.Subject, identity.Tenant, identity.Plan)
 	req.Header.Set("Authorization", "Bearer foo."+rawclaims+".bar")
 
 	recorded := test.RunRequest(t, handler, req)
@@ -88,7 +88,7 @@ func TestIdentityMiddlewareNoTenant(t *testing.T) {
 	handler := api.MakeHandler()
 
 	req := test.MakeSimpleRequest("GET", "http://localhost/", nil)
-	rawclaims := makeClaimsPart(identity.Subject, identity.Tenant)
+	rawclaims := makeClaimsPart(identity.Subject, identity.Tenant, identity.Plan)
 	req.Header.Set("Authorization", "Bearer foo."+rawclaims+".bar")
 
 	recorded := test.RunRequest(t, handler, req)
@@ -104,6 +104,7 @@ func TestIdentityMiddleware(t *testing.T) {
 	identity := Identity{
 		Subject: "foo",
 		Tenant:  "bar",
+		Plan:    "os",
 	}
 
 	api.SetApp(rest.AppSimple(func(w rest.ResponseWriter, r *rest.Request) {
@@ -115,7 +116,7 @@ func TestIdentityMiddleware(t *testing.T) {
 	handler := api.MakeHandler()
 
 	req := test.MakeSimpleRequest("GET", "http://localhost/", nil)
-	rawclaims := makeClaimsPart(identity.Subject, identity.Tenant)
+	rawclaims := makeClaimsPart(identity.Subject, identity.Tenant, identity.Plan)
 	req.Header.Set("Authorization", "Bearer foo."+rawclaims+".bar")
 
 	recorded := test.RunRequest(t, handler, req)
@@ -133,6 +134,7 @@ func TestIdentityMiddlewareDevice(t *testing.T) {
 			identity: Identity{
 				Subject:  "device-1",
 				Tenant:   "bar",
+				Plan:     "os",
 				IsDevice: true,
 			},
 			mw: &IdentityMiddleware{
@@ -141,12 +143,14 @@ func TestIdentityMiddlewareDevice(t *testing.T) {
 			logFields: map[string]interface{}{
 				"device_id": "device-1",
 				"tenant_id": "bar",
+				"plan":      "os",
 			},
 		},
 		{
 			identity: Identity{
 				Subject: "user-1",
 				Tenant:  "bar",
+				Plan:    "os",
 				IsUser:  true,
 			},
 			mw: &IdentityMiddleware{
@@ -155,12 +159,14 @@ func TestIdentityMiddlewareDevice(t *testing.T) {
 			logFields: map[string]interface{}{
 				"user_id":   "user-1",
 				"tenant_id": "bar",
+				"plan":      "os",
 			},
 		},
 		{
 			identity: Identity{
 				Subject: "not-a-user-not-a-device",
 				Tenant:  "bar",
+				Plan:    "os",
 			},
 			mw: &IdentityMiddleware{
 				UpdateLogger: true,
@@ -168,6 +174,7 @@ func TestIdentityMiddlewareDevice(t *testing.T) {
 			logFields: map[string]interface{}{
 				"sub":       "not-a-user-not-a-device",
 				"tenant_id": "bar",
+				"plan":      "os",
 			},
 		},
 		{
@@ -209,7 +216,7 @@ func TestIdentityMiddlewareDevice(t *testing.T) {
 
 			req := test.MakeSimpleRequest("GET", "http://localhost/", nil)
 
-			claims := makeClaimsFull(tc.identity.Subject, tc.identity.Tenant,
+			claims := makeClaimsFull(tc.identity.Subject, tc.identity.Tenant, tc.identity.Plan,
 				tc.identity.IsDevice, tc.identity.IsUser)
 			req.Header.Set("Authorization", "Bearer foo."+claims+".bar")
 

--- a/identity/token_test.go
+++ b/identity/token_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -26,15 +26,17 @@ func boolPtr(val bool) *bool {
 	return &val
 }
 
-func makeClaimsFull(sub, tenant string, device, user bool) string {
+func makeClaimsFull(sub, tenant, plan string, device, user bool) string {
 	claim := struct {
 		Subject string `json:"sub,omitempty"`
 		Tenant  string `json:"mender.tenant,omitempty"`
 		Device  *bool  `json:"mender.device,omitempty"`
 		User    *bool  `json:"mender.user,omitempty"`
+		Plan    string `json:"mender.plan,omitempty"`
 	}{
 		Subject: sub,
 		Tenant:  tenant,
+		Plan:    plan,
 	}
 
 	if device {
@@ -49,8 +51,8 @@ func makeClaimsFull(sub, tenant string, device, user bool) string {
 	return rawclaim
 }
 
-func makeClaimsPart(sub, tenant string) string {
-	return makeClaimsFull(sub, tenant, false, false)
+func makeClaimsPart(sub, tenant, plan string) string {
+	return makeClaimsFull(sub, tenant, plan, false, false)
 }
 
 func TestExtractIdentity(t *testing.T) {
@@ -64,7 +66,7 @@ func TestExtractIdentity(t *testing.T) {
 	assert.Error(t, err)
 
 	// should fail, token is malformed, missing header & signature
-	rawclaims := makeClaimsPart("foobar", "")
+	rawclaims := makeClaimsPart("foobar", "", "")
 	_, err = ExtractIdentity(rawclaims)
 	assert.Error(t, err)
 
@@ -114,7 +116,7 @@ func TestExtractIdentityFromHeaders(t *testing.T) {
 	assert.Error(t, err)
 
 	// correct cate
-	rawclaims := makeClaimsPart("foobar", "")
+	rawclaims := makeClaimsPart("foobar", "", "")
 	h.Set("Authorization", "Bearer foo."+rawclaims+".bar")
 	idata, err := ExtractIdentityFromHeaders(h)
 	assert.NoError(t, err)
@@ -133,7 +135,7 @@ func TestDecodeClaims(t *testing.T) {
 	assert.Error(t, err)
 
 	// should fail, token is malformed, missing header & signature
-	rawclaims := makeClaimsPart("foobar", "")
+	rawclaims := makeClaimsPart("foobar", "", "")
 	_, err = decodeClaims(rawclaims)
 	assert.Error(t, err)
 


### PR DESCRIPTION
Our services are using identity middleware to extract some claims (like sub, mender.tenant, etc.) from JWT and passed them to the context.
With this change, identity middleware will extract "mender.plan" claim also.