### PR TITLE
Feature/dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: 'go:modules'
+    directory: '/'
+    update_schedule: 'weekly'


### PR DESCRIPTION
added dependabot configuration to activate notifications
this is only for notification purposes
- due to the limited configuration options for the commit messages