### PR TITLE
Remove captialization of rest_utils error response helpers

### DIFF
--- a/rest_utils/api_error.go
+++ b/rest_utils/api_error.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import (
 // ApiError wraps errors returned by our APIs
 type ApiError struct {
 	Err   string `json:"error"`
-	ReqId string `json:"request_id"`
+	ReqId string `json:"request_id,omitempty"`
 }
 
 func (ae *ApiError) Error() string {

--- a/rest_utils/response_helpers.go
+++ b/rest_utils/response_helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -92,9 +92,9 @@ func restErrWithLogMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger,
 	}
 
 	w.WriteHeader(code)
-	err := w.WriteJson(map[string]string{
-		rest.ErrorFieldName: msg,
-		"request_id":        requestid.GetReqId(r),
+	err := w.WriteJson(ApiError{
+		Err:   msg,
+		ReqId: requestid.GetReqId(r),
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Just a small inconsistency fix. Now the rest_utils response handlers use the ApiError defined in the same package, which doesn't capitalize the error field in the JSON structure.