### PR TITLE
FIX: log.ContextHook missfire

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -129,7 +129,7 @@ func (hook ContextHook) Fire(entry *logrus.Entry) error {
 			funcName := runtime.FuncForPC(pc).Name()
 
 			//detect if we're still in logrus (formatting funcs)
-			if !strings.Contains(funcName, "github.com/Sirupsen/logrus") {
+			if !strings.Contains(funcName, "github.com/sirupsen/logrus") {
 				entry.Data["file"] = path.Base(file)
 				entry.Data["func"] = path.Base(funcName)
 				entry.Data["line"] = line


### PR DESCRIPTION
Always ends on the wrong file because github.com/Sirupsen/logrus
switched to lower-case.