### PR TITLE
identity: Use URL encoding to parse base64 claims

### DIFF
--- a/identity/token.go
+++ b/identity/token.go
@@ -53,7 +53,7 @@ func decodeClaims(token string) (rawClaims, error) {
 		b64claims += strings.Repeat("=", 4-pad)
 	}
 
-	rawclaims, err := base64.StdEncoding.DecodeString(b64claims)
+	rawclaims, err := base64.URLEncoding.DecodeString(b64claims)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to decode raw claims %v",
 			b64claims)

--- a/identity/token_test.go
+++ b/identity/token_test.go
@@ -46,7 +46,7 @@ func makeClaimsFull(sub, tenant, plan string, device, user bool) string {
 		claim.User = boolPtr(true)
 	}
 	data, _ := json.Marshal(&claim)
-	rawclaim := base64.StdEncoding.EncodeToString(data)
+	rawclaim := base64.URLEncoding.EncodeToString(data)
 
 	return rawclaim
 }
@@ -76,26 +76,26 @@ func TestExtractIdentity(t *testing.T) {
 	assert.Equal(t, Identity{Subject: "foobar"}, idata)
 
 	// missing subject
-	enc := base64.StdEncoding.EncodeToString([]byte(`{"iss": "Mender"}`))
+	enc := base64.URLEncoding.EncodeToString([]byte(`{"iss": "Mender"}`))
 	_, err = ExtractIdentity("foo." + enc + ".bar")
 	assert.Error(t, err)
 
 	// bad subject
-	enc = base64.StdEncoding.EncodeToString([]byte(`{"sub": 1}`))
+	enc = base64.URLEncoding.EncodeToString([]byte(`{"sub": 1}`))
 	_, err = ExtractIdentity("foo." + enc + ".bar")
 	assert.Error(t, err)
 
-	enc = base64.StdEncoding.EncodeToString([]byte(`{"sub": "123", "mender.device": true}`))
+	enc = base64.URLEncoding.EncodeToString([]byte(`{"sub": "123", "mender.device": true}`))
 	idata, err = ExtractIdentity("foo." + enc + ".bar")
 	assert.NoError(t, err)
 	assert.Equal(t, Identity{Subject: "123", IsDevice: true}, idata)
 
-	enc = base64.StdEncoding.EncodeToString([]byte(`{"sub": "123", "mender.user": true}`))
+	enc = base64.URLEncoding.EncodeToString([]byte(`{"sub": "123", "mender.user": true}`))
 	idata, err = ExtractIdentity("foo." + enc + ".bar")
 	assert.NoError(t, err)
 	assert.Equal(t, Identity{Subject: "123", IsUser: true}, idata)
 
-	enc = base64.StdEncoding.EncodeToString([]byte(`{"sub": "123", "mender.user": {"garbage": 2}}`))
+	enc = base64.URLEncoding.EncodeToString([]byte(`{"sub": "123", "mender.user": {"garbage": 2}}`))
 	idata, err = ExtractIdentity("foo." + enc + ".bar")
 	assert.NoError(t, err)
 	assert.Equal(t, Identity{Subject: "123"}, idata)
@@ -144,7 +144,7 @@ func TestDecodeClaims(t *testing.T) {
 	assert.Error(t, err)
 
 	// malformed json
-	enc := base64.StdEncoding.EncodeToString([]byte(`"sub": 1}`))
+	enc := base64.URLEncoding.EncodeToString([]byte(`"sub": 1}`))
 	_, err = ExtractIdentity("foo." + enc + ".bar")
 
 	assert.Error(t, err)


### PR DESCRIPTION
Using `StdEncoding` to parse jwt claims looks very wrong here. 
The original claims are generated by `jwt-go` library in the `deviceauth` (see https://github.com/mendersoftware/deviceauth/blob/master/jwt/jwt.go#L50) and internally `jwt-go` uses `URLEncoding` (see https://github.com/dgrijalva/jwt-go/blob/master/token.go#L98).
As the result in some specific cases jwt tokens have specific chars such as `_-` and `decodeClaims` function fails with `illegal base64 data at input byte`.

In addition, `inventory` service has the duplicate of this code in `utils/identity` with the same issue.