### PR TITLE
Allow passing JWT as a cookie

### DIFF
--- a/identity/middleware.go
+++ b/identity/middleware.go
@@ -42,7 +42,7 @@ func (mw *IdentityMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFun
 
 		l := log.FromContext(ctx)
 
-		identity, err := ExtractIdentityFromHeaders(r.Header)
+		identity, err := ExtractIdentityFromHeaders(r.Request)
 		if err != nil {
 			l.Warnf("Failed to extract identity from header: %v", err)
 		} else {

--- a/identity/middleware.go
+++ b/identity/middleware.go
@@ -37,14 +37,20 @@ type IdentityMiddleware struct {
 // MiddlewareFunc makes IdentityMiddleware implement the Middleware interface.
 func (mw *IdentityMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFunc {
 	return func(w rest.ResponseWriter, r *rest.Request) {
+		jwt, err := ExtractJWTFromHeader(r.Request)
+		if err != nil {
+			h(w, r)
+			return
+		}
 
 		ctx := r.Context()
-
 		l := log.FromContext(ctx)
 
-		identity, err := ExtractIdentityFromHeaders(r.Request)
+		identity, err := ExtractIdentity(jwt)
 		if err != nil {
-			l.Warnf("Failed to extract identity from header: %v", err)
+			l.Warnf("Failed to parse extracted JWT: %s",
+				err.Error(),
+			)
 		} else {
 			if mw.UpdateLogger {
 				logCtx := log.Ctx{}

--- a/identity/token.go
+++ b/identity/token.go
@@ -30,6 +30,31 @@ type Identity struct {
 	Plan     string `json:"mender.plan,omitempty"`
 }
 
+// ExtractJWTFromHeader inspect the Authorization header for a Bearer token and
+// if not present looks for a "JWT" cookie.
+func ExtractJWTFromHeader(r *http.Request) (jwt string, err error) {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		jwtCookie, err := r.Cookie("JWT")
+		if err != nil {
+			return "", errors.New("Authorization not present in header")
+		}
+		jwt = jwtCookie.Value
+	} else {
+		auths := strings.Split(auth, " ")
+
+		if len(auths) != 2 {
+			return "", errors.Errorf("malformed Authorization header")
+		}
+
+		if !strings.EqualFold(auths[0], "Bearer") {
+			return "", errors.Errorf("unknown Authorization method %s", auths[0])
+		}
+		jwt = auths[1]
+	}
+	return jwt, nil
+}
+
 // Generate identity information from given JWT by extracting subject and tenant claims.
 // Note that this function does not perform any form of token signature
 // verification.
@@ -58,34 +83,6 @@ func ExtractIdentity(token string) (id Identity, err error) {
 			"identity: failed to decode JSON JWT claims")
 	}
 	return id, id.Validate()
-}
-
-// Extract identity information from HTTP Authorization header. The header is
-// assumed to contain data in format: `Bearer <token>`
-func ExtractIdentityFromHeaders(r *http.Request) (Identity, error) {
-	var jwt string
-	auth := r.Header.Get("Authorization")
-	if auth == "" {
-		// Try "JWT" cookie
-		jwtCookie, err := r.Cookie("JWT")
-		if err != nil {
-			return Identity{}, errors.New("Authorization not present in header")
-		}
-		jwt = jwtCookie.Value
-	} else {
-		auths := strings.Split(auth, " ")
-
-		if len(auths) != 2 {
-			return Identity{}, errors.Errorf("malformed authorization data")
-		}
-
-		if auths[0] != "Bearer" {
-			return Identity{}, errors.Errorf("unknown authorization method %s", auths[0])
-		}
-		jwt = auths[1]
-	}
-
-	return ExtractIdentity(jwt)
 }
 
 func (id Identity) Validate() error {

--- a/identity/token_test.go
+++ b/identity/token_test.go
@@ -109,30 +109,31 @@ func TestExtractIdentityFromHeaders(t *testing.T) {
 	r := &http.Request{
 		Header: http.Header{},
 	}
-	_, err := ExtractIdentityFromHeaders(r)
+	_, err := ExtractJWTFromHeader(r)
 	assert.Error(t, err)
 
 	r.Header.Set("Authorization", "Basic foobar")
-	_, err = ExtractIdentityFromHeaders(r)
+	_, err = ExtractJWTFromHeader(r)
 	assert.Error(t, err)
 
 	r.Header.Set("Authorization", "Bearer")
-	_, err = ExtractIdentityFromHeaders(r)
+	_, err = ExtractJWTFromHeader(r)
 	assert.Error(t, err)
 
 	// correct cate
 	rawclaims := makeClaimsPart("foobar", "", "")
-	r.Header.Set("Authorization", "Bearer foo."+rawclaims+".bar")
-	idata, err := ExtractIdentityFromHeaders(r)
+	actualJWT := "foo." + rawclaims + ".bar"
+	r.Header.Set("Authorization", "Bearer "+actualJWT)
+	jwt, err := ExtractJWTFromHeader(r)
 	assert.NoError(t, err)
-	assert.Equal(t, Identity{Subject: "foobar"}, idata)
+	assert.Equal(t, actualJWT, jwt)
 
 	r.Header.Del("Authorization")
 	r.AddCookie(&http.Cookie{
 		Name:  "JWT",
 		Value: "foo." + rawclaims + ".bar",
 	})
-	idata, err = ExtractIdentityFromHeaders(r)
+	jwt, err = ExtractJWTFromHeader(r)
 	assert.NoError(t, err)
-	assert.Equal(t, Identity{Subject: "foobar"}, idata)
+	assert.Equal(t, actualJWT, jwt)
 }


### PR DESCRIPTION
Passing the JWT as cookie allows passing the authorization token to downloadable URLs and upgrading to websockets from the browser.