### PR TITLE
identity: Use URL encoding to parse base64 claims

### DIFF
--- a/identity/token.go
+++ b/identity/token.go
@@ -60,19 +60,14 @@ func ExtractJWTFromHeader(r *http.Request) (jwt string, err error) {
 // verification.
 func ExtractIdentity(token string) (id Identity, err error) {
 	var (
-		b64Claims string
-		claims    []byte
-		jwt       []string
+		claims []byte
+		jwt    []string
 	)
 	jwt = strings.Split(token, ".")
 	if len(jwt) != 3 {
 		return id, errors.New("identity: incorrect token format")
 	}
-	b64Claims = jwt[1]
-	if pad := len(b64Claims) % 4; pad != 0 {
-		b64Claims += strings.Repeat("=", 4-pad)
-	}
-	claims, err = base64.StdEncoding.DecodeString(b64Claims)
+	claims, err = base64.RawURLEncoding.DecodeString(jwt[1])
 	if err != nil {
 		return id, errors.Wrap(err,
 			"identity: failed to decode base64 JWT claims")

--- a/identity/token_test.go
+++ b/identity/token_test.go
@@ -17,7 +17,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,7 +46,7 @@ func makeClaimsFull(sub, tenant, plan string, device, user bool) string {
 		claim.User = boolPtr(true)
 	}
 	data, _ := json.Marshal(&claim)
-	rawclaim := strings.TrimRight(base64.StdEncoding.EncodeToString(data), "=")
+	rawclaim := base64.RawURLEncoding.EncodeToString(data)
 	return rawclaim
 }
 
@@ -76,26 +75,26 @@ func TestExtractIdentity(t *testing.T) {
 	assert.Equal(t, Identity{Subject: "foobar"}, idata)
 
 	// missing subject
-	enc := base64.StdEncoding.EncodeToString([]byte(`{"iss": "Mender"}`))
+	enc := base64.RawURLEncoding.EncodeToString([]byte(`{"iss": "Mender"}`))
 	_, err = ExtractIdentity("foo." + enc + ".bar")
 	assert.Error(t, err)
 
 	// bad subject
-	enc = base64.StdEncoding.EncodeToString([]byte(`{"sub": 1}`))
+	enc = base64.RawURLEncoding.EncodeToString([]byte(`{"sub": 1}`))
 	_, err = ExtractIdentity("foo." + enc + ".bar")
 	assert.Error(t, err)
 
-	enc = base64.StdEncoding.EncodeToString([]byte(`{"sub": "123", "mender.device": true}`))
+	enc = base64.RawURLEncoding.EncodeToString([]byte(`{"sub": "123", "mender.device": true}`))
 	idata, err = ExtractIdentity("foo." + enc + ".bar")
 	assert.NoError(t, err)
 	assert.Equal(t, Identity{Subject: "123", IsDevice: true}, idata)
 
-	enc = base64.StdEncoding.EncodeToString([]byte(`{"sub": "123", "mender.user": true}`))
+	enc = base64.RawURLEncoding.EncodeToString([]byte(`{"sub": "123", "mender.user": true}`))
 	idata, err = ExtractIdentity("foo." + enc + ".bar")
 	assert.NoError(t, err)
 	assert.Equal(t, Identity{Subject: "123", IsUser: true}, idata)
 
-	enc = base64.StdEncoding.EncodeToString([]byte(`{"sub": "123", "mender.user": {"garbage": 2}}`))
+	enc = base64.RawURLEncoding.EncodeToString([]byte(`{"sub": "123", "mender.user": {"garbage": 2}}`))
 	_, err = ExtractIdentity("foo." + enc + ".bar")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to decode JSON JWT claims")


### PR DESCRIPTION
Original fix by @mainnika #80
As pointed out in #80, there is a risk of encoding bad base64 tokens.
Moreover, the JWT specification [RFC 7519] specifies the URL-safe
variant of base64 encoding should be used.