### PR TITLE
Remove Path from LogParameters, add qs to default log context

### DIFF
--- a/accesslog/middleware_gin.go
+++ b/accesslog/middleware_gin.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -28,9 +28,6 @@ type LogParameters struct {
 	// gin.Context.
 	Context *gin.Context
 
-	// Path holds the path as set before the request handler is executed.
-	Path string
-
 	// StartTime is the time when the request was received by the
 	// middleware, which can be used to compute latency.
 	StartTime time.Time
@@ -52,7 +49,8 @@ func defaultLogHook(params LogParameters) {
 		"byteswritten": size,
 		"clientip":     c.ClientIP(),
 		"method":       c.Request.Method,
-		"path":         params.Path,
+		"path":         c.Request.URL.Path,
+		"qs":           c.Request.URL.RawQuery,
 		"responsetime": fmt.Sprintf("%dus",
 			latency.Round(time.Microsecond).Microseconds()),
 		"status":    code,
@@ -132,11 +130,7 @@ func Middleware(opts ...*MiddlewareOptions) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		params := LogParameters{
 			Context:   c,
-			Path:      c.Request.URL.Path,
 			StartTime: time.Now(),
-		}
-		if c.Request.URL.RawQuery != "" {
-			params.Path = params.Path + "?" + c.Request.URL.RawQuery
 		}
 
 		if opt.BeforeHook != nil {

--- a/accesslog/middleware_gin_test.go
+++ b/accesslog/middleware_gin_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -44,7 +44,8 @@ func TestMiddleware(t *testing.T) {
 		},
 		Fields: []string{
 			"status=204",
-			`path="/test?foo=bar"`,
+			`path=/test`,
+			`qs="foo=bar"`,
 			"method=GET",
 			"useragent=tester",
 			"responsetime=",
@@ -61,7 +62,8 @@ func TestMiddleware(t *testing.T) {
 		},
 		Fields: []string{
 			"status=500",
-			`path="/test?foo=bar"`,
+			`path=/test`,
+			`qs="foo=bar"`,
 			"method=GET",
 			"responsetime=",
 			"byteswritten=14",
@@ -81,7 +83,8 @@ func TestMiddleware(t *testing.T) {
 		},
 		Fields: []string{
 			"status=500",
-			`path="/test?foo=bar"`,
+			`path=/test`,
+			`qs="foo=bar"`,
 			"useragent=tester",
 			"method=GET",
 			"responsetime=",
@@ -98,7 +101,8 @@ func TestMiddleware(t *testing.T) {
 		},
 		Fields: []string{
 			"status=400",
-			`path="/test?foo=bar"`,
+			`path=/test`,
+			`qs="foo=bar"`,
 			"method=GET",
 			"responsetime=",
 			"useragent=tester",


### PR DESCRIPTION
We will need to redact RawQuery and possibly url paths from sensitive
parameters. Moreover, using the 'unmodified' values breaks with the
go-json-rest version of the middleware.