### PR TITLE
Remove default regex from identity middleware and add panic recovery to accesslog

### DIFF
--- a/accesslog/middleware_gin.go
+++ b/accesslog/middleware_gin.go
@@ -17,129 +17,140 @@ package accesslog
 import (
 	"fmt"
 	"net/http"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/mendersoftware/go-lib-micro/log"
+	"github.com/mendersoftware/go-lib-micro/rest.utils"
+	"github.com/pkg/errors"
 )
 
-type LogParameters struct {
-	// Context contains the entire request context as exposed by
-	// gin.Context.
-	Context *gin.Context
+const MaxTraceback = 32
 
-	// StartTime is the time when the request was received by the
-	// middleware, which can be used to compute latency.
-	StartTime time.Time
+func funcname(fn string) string {
+	// strip package path
+	i := strings.LastIndex(fn, "/")
+	fn = fn[i+1:]
+	// strip package name.
+	i = strings.Index(fn, ".")
+	fn = fn[i+1:]
+	return fn
 }
 
-type LogHook func(parms LogParameters)
-
-func defaultLogHook(params LogParameters) {
-	latency := time.Since(params.StartTime)
-	c := params.Context
-	l := log.FromContext(c.Request.Context())
-	code := c.Writer.Status()
-	// Add status and response time to log context
-	size := c.Writer.Size()
-	if size < 0 {
-		size = 0
-	}
-	logCtx := log.Ctx{
-		"byteswritten": size,
-		"clientip":     c.ClientIP(),
-		"method":       c.Request.Method,
-		"path":         c.Request.URL.Path,
-		"qs":           c.Request.URL.RawQuery,
-		"responsetime": fmt.Sprintf("%dus",
-			latency.Round(time.Microsecond).Microseconds()),
-		"status":    code,
-		"ts":        params.StartTime.Format(time.RFC3339),
-		"type":      c.Request.Proto,
-		"useragent": c.Request.UserAgent(),
-	}
-	l = l.F(logCtx)
-
-	if code < 400 {
-		l.Info()
-	} else {
-		if len(c.Errors) > 0 {
-			errs := c.Errors.Errors()
-			var errMsg string
-			if len(errs) == 1 {
-				errMsg = errs[0]
-			} else {
-				for i, err := range errs {
-					errMsg = errMsg + fmt.Sprintf(
-						"#%02d: %s\n", i+1, err,
-					)
-				}
+func panicHandler(c *gin.Context, startTime time.Time) {
+	if r := recover(); r != nil {
+		l := log.FromContext(c.Request.Context())
+		latency := time.Since(startTime)
+		trace := [MaxTraceback]uintptr{}
+		// Skip 3
+		// = runtime.Callers + runtime.extern.Callers + runtime.gopanic
+		num := runtime.Callers(3, trace[:])
+		var traceback strings.Builder
+		for i := 0; i < num; i++ {
+			fn := runtime.FuncForPC(trace[i])
+			if fn == nil {
+				fmt.Fprintf(&traceback, "\n???")
+				continue
 			}
-			l = l.F(log.Ctx{
-				"error": errMsg,
-			})
-		} else {
-			l = l.F(log.Ctx{
-				"error": http.StatusText(code),
-			})
+			file, line := fn.FileLine(trace[i])
+			fmt.Fprintf(&traceback, "\n%s(%s):%d",
+				file, funcname(fn.Name()), line,
+			)
 		}
-		l.Error()
+
+		logCtx := log.Ctx{
+			"clientip": c.ClientIP(),
+			"method":   c.Request.Method,
+			"path":     c.Request.URL.Path,
+			"qs":       c.Request.URL.RawQuery,
+			"responsetime": fmt.Sprintf("%dus",
+				latency.Round(time.Microsecond).Microseconds()),
+			"status":    500,
+			"ts":        startTime.Format(time.RFC3339),
+			"type":      c.Request.Proto,
+			"useragent": c.Request.UserAgent(),
+			"trace":     traceback.String()[1:],
+		}
+		l = l.F(logCtx)
+		func() {
+			// Panic is going to panic, but we
+			// immediately want to recover.
+			defer func() { recover() }() //nolint:errcheck
+			l.Panicf("[request panic] %s", r)
+		}()
+
+		// Try to respond with an internal server error.
+		// If the connection is broken it might panic again.
+		defer func() { recover() }() // nolint:errcheck
+		rest.RenderError(c,
+			http.StatusInternalServerError,
+			errors.New("internal error"),
+		)
 	}
-}
-
-type MiddlewareOptions struct {
-	BeforeHook LogHook
-
-	AfterHook LogHook
-}
-
-func NewMiddlewareOptions() *MiddlewareOptions {
-	return &MiddlewareOptions{}
-}
-
-func (opt *MiddlewareOptions) SetBeforeHook(logHook LogHook) *MiddlewareOptions {
-	opt.BeforeHook = logHook
-	return opt
-}
-
-func (opt *MiddlewareOptions) SetAfterHook(logHook LogHook) *MiddlewareOptions {
-	opt.AfterHook = logHook
-	return opt
 }
 
 // Middleware provides accesslog middleware for the gin-gonic framework.
-// The middleware enriches the log context with "method" and "path" context
-// and adds a log entry to all request reporting the response time and status-
-// code. If an error status is returned in the response, the middleware tries
+// This middleware will recover any panic from the occurring in the API
+// handler and log it to panic level.
+// If an error status is returned in the response, the middleware tries
 // to pop the topmost error from the gin.Context (c.Error) and puts it in
 // the "error" context to the final log entry.
-func Middleware(opts ...*MiddlewareOptions) gin.HandlerFunc {
-	opt := NewMiddlewareOptions().
-		SetAfterHook(defaultLogHook)
-	for _, o := range opts {
-		if o == nil {
-			continue
-		}
-		if o.AfterHook != nil {
-			opt.AfterHook = o.AfterHook
-		}
-		if o.BeforeHook != nil {
-			opt.BeforeHook = o.BeforeHook
-		}
-	}
+func Middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		params := LogParameters{
-			Context:   c,
-			StartTime: time.Now(),
-		}
+		startTime := time.Now()
+		defer panicHandler(c, startTime)
 
-		if opt.BeforeHook != nil {
-			opt.BeforeHook(params)
-		}
-
-		// Perform the request
 		c.Next()
 
-		opt.AfterHook(params)
+		l := log.FromContext(c.Request.Context())
+		latency := time.Since(startTime)
+		code := c.Writer.Status()
+		// Add status and response time to log context
+		size := c.Writer.Size()
+		if size < 0 {
+			size = 0
+		}
+		logCtx := log.Ctx{
+			"byteswritten": size,
+			"clientip":     c.ClientIP(),
+			"method":       c.Request.Method,
+			"path":         c.Request.URL.Path,
+			"qs":           c.Request.URL.RawQuery,
+			"responsetime": fmt.Sprintf("%dus",
+				latency.Round(time.Microsecond).Microseconds()),
+			"status":    code,
+			"ts":        startTime.Format(time.RFC3339),
+			"type":      c.Request.Proto,
+			"useragent": c.Request.UserAgent(),
+		}
+		l = l.F(logCtx)
+
+		if code < 400 {
+			l.Info()
+		} else {
+			if len(c.Errors) > 0 {
+				errs := c.Errors.Errors()
+				var errMsg string
+				if len(errs) == 1 {
+					errMsg = errs[0]
+				} else {
+					for i, err := range errs {
+						errMsg = errMsg + fmt.Sprintf(
+							"#%02d: %s\n", i+1, err,
+						)
+					}
+				}
+				l = l.F(log.Ctx{
+					"error": errMsg,
+				})
+			} else {
+				l = l.F(log.Ctx{
+					"error": http.StatusText(code),
+				})
+			}
+			l.Error()
+		}
 	}
 }


### PR DESCRIPTION
This will break compatibility with the old version of the middleware, but since it's only in use by one service (mendersoftware/deviceconnect) I'll make sure to make the necessary adjustments.