### PR TITLE
store/v2: Add "tenant_id" field unconditionally in WithTenantID

### DIFF
--- a/mongo/doc/bson.go
+++ b/mongo/doc/bson.go
@@ -60,7 +60,7 @@ func DocumentFromStruct(
 
 	numAppends := len(appendElements)
 	numFields := s.NumField()
-	doc = make(bson.D, 0, numFields)
+	doc = make(bson.D, 0, numFields+numAppends)
 	fields := s.Type()
 	for i := 0; i < numFields; i++ {
 		field := fields.Field(i)

--- a/store/v2/utils.go
+++ b/store/v2/utils.go
@@ -30,12 +30,14 @@ const FieldTenantID = "tenant_id"
 // WithTenantID adds the tenant_id field to a bson document using the value extracted
 // from the identity of the context
 func WithTenantID(ctx context.Context, doc interface{}) bson.D {
+	var tenantID string
 	res := bson.D{}
 
 	identity := identity.FromContext(ctx)
 	if identity != nil {
-		res = append(res, bson.E{Key: FieldTenantID, Value: identity.Tenant})
+		tenantID = identity.Tenant
 	}
+	res = append(res, bson.E{Key: FieldTenantID, Value: tenantID})
 
 	switch v := doc.(type) {
 	case map[string]interface{}:

--- a/store/v2/utils.go
+++ b/store/v2/utils.go
@@ -30,31 +30,45 @@ const FieldTenantID = "tenant_id"
 // WithTenantID adds the tenant_id field to a bson document using the value extracted
 // from the identity of the context
 func WithTenantID(ctx context.Context, doc interface{}) bson.D {
-	var tenantID string
-	res := bson.D{}
+	var (
+		tenantID string
+		res      bson.D
+	)
 
 	identity := identity.FromContext(ctx)
 	if identity != nil {
 		tenantID = identity.Tenant
 	}
-	res = append(res, bson.E{Key: FieldTenantID, Value: tenantID})
+	tenantElem := bson.E{Key: FieldTenantID, Value: tenantID}
 
 	switch v := doc.(type) {
 	case map[string]interface{}:
+		res = make(bson.D, 0, len(v)+1)
 		for k, v := range v {
 			res = append(res, bson.E{Key: k, Value: v})
 		}
 	case bson.M:
+		res = make(bson.D, 0, len(v)+1)
 		for k, v := range v {
 			res = append(res, bson.E{Key: k, Value: v})
 		}
 	case bson.D:
-		res = append(res, v...)
-	default:
-		if bsonData := mdoc.MarshallBSONOrDocumentFromStruct(v); bsonData != nil {
-			res = append(res, bsonData...)
+		res = make(bson.D, len(v), len(v)+1)
+		copy(res, v)
+
+	case bson.Marshaler:
+		b, err := v.MarshalBSON()
+		if err != nil {
+			return nil
 		}
+		err = bson.Unmarshal(b, &res)
+		if err != nil {
+			return nil
+		}
+	default:
+		return mdoc.DocumentFromStruct(v, tenantElem)
 	}
+	res = append(res, tenantElem)
 
 	return res
 }

--- a/store/v2/utils_test.go
+++ b/store/v2/utils_test.go
@@ -15,6 +15,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,26 +28,60 @@ type SampleObject struct {
 	Attribute string `json:"attribute" bson:"attribute"`
 }
 
+type SampleMarshalerObject struct {
+	Attribute string
+}
+
+func (s SampleMarshalerObject) MarshalBSON() ([]byte, error) {
+	m := map[string]string{}
+	m["attribute"] = s.Attribute
+	return bson.Marshal(m)
+}
+
+type SampleBadMarshalerObject struct{ Foo bool }
+
+func (SampleBadMarshalerObject) MarshalBSON() ([]byte, error) {
+	return nil, errors.New("dunno")
+}
+
+type SampleBadMarshalerObject2 struct{ Foo bool }
+
+func (SampleBadMarshalerObject2) MarshalBSON() ([]byte, error) {
+	return []byte("this is an invalid BSON type"), nil
+}
+
 func TestWithTenantID(t *testing.T) {
 	ctx := context.Background()
 
 	sample := &SampleObject{Attribute: "value"}
+	sample2 := SampleMarshalerObject{Attribute: "val"}
+	sampleBad := SampleBadMarshalerObject{}
+	sampleBad2 := SampleBadMarshalerObject2{}
 
 	// without tenant ID
 	res := WithTenantID(ctx, map[string]interface{}{"key": "value"})
-	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: ""}, {Key: "key", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: "key", Value: "value"}, {Key: FieldTenantID, Value: ""}}, res)
 
 	res = WithTenantID(ctx, bson.M{"key": "value"})
-	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: ""}, {Key: "key", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: "key", Value: "value"}, {Key: FieldTenantID, Value: ""}}, res)
 
 	res = WithTenantID(ctx, bson.D{{Key: "key", Value: "value"}})
-	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: ""}, {Key: "key", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: "key", Value: "value"}, {Key: FieldTenantID, Value: ""}}, res)
 
 	res = WithTenantID(ctx, sample)
-	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: ""}, {Key: "attribute", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: "attribute", Value: "value"}, {Key: FieldTenantID, Value: ""}}, res)
+
+	res = WithTenantID(ctx, sample2)
+	assert.Equal(t, bson.D{{Key: "attribute", Value: "val"}, {Key: FieldTenantID, Value: ""}}, res)
+
+	res = WithTenantID(ctx, sampleBad)
+	assert.Nil(t, res)
+
+	res = WithTenantID(ctx, sampleBad2)
+	assert.Nil(t, res)
 
 	res = WithTenantID(ctx, "dummy-value")
-	assert.Equal(t, bson.D{}, res)
+	assert.Nil(t, res)
 
 	// with tenant ID
 	const tenantID = "bar"
@@ -57,19 +92,19 @@ func TestWithTenantID(t *testing.T) {
 	ctx = identity.WithContext(ctx, id)
 
 	res = WithTenantID(ctx, map[string]interface{}{"key": "value"})
-	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: tenantID}, {Key: "key", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: "key", Value: "value"}, {Key: FieldTenantID, Value: tenantID}}, res)
 
 	res = WithTenantID(ctx, bson.M{"key": "value"})
-	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: tenantID}, {Key: "key", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: "key", Value: "value"}, {Key: FieldTenantID, Value: tenantID}}, res)
 
 	res = WithTenantID(ctx, bson.D{{Key: "key", Value: "value"}})
-	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: tenantID}, {Key: "key", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: "key", Value: "value"}, {Key: FieldTenantID, Value: tenantID}}, res)
 
 	res = WithTenantID(ctx, sample)
-	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: tenantID}, {Key: "attribute", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: "attribute", Value: "value"}, {Key: FieldTenantID, Value: tenantID}}, res)
 
 	res = WithTenantID(ctx, "dummy-value")
-	assert.Equal(t, bson.D{}, res)
+	assert.Nil(t, res)
 }
 
 func TestArrayWithTenantID(t *testing.T) {
@@ -77,7 +112,7 @@ func TestArrayWithTenantID(t *testing.T) {
 
 	// without tenant ID
 	res := ArrayWithTenantID(ctx, bson.A{bson.M{"key": "value"}})
-	assert.Equal(t, bson.A{bson.D{{Key: FieldTenantID, Value: ""}, {Key: "key", Value: "value"}}}, res)
+	assert.Equal(t, bson.A{bson.D{{Key: "key", Value: "value"}, {Key: FieldTenantID, Value: ""}}}, res)
 
 	// with tenant ID
 	const tenantID = "bar"
@@ -88,7 +123,7 @@ func TestArrayWithTenantID(t *testing.T) {
 	ctx = identity.WithContext(ctx, id)
 
 	res = ArrayWithTenantID(ctx, bson.A{bson.M{"key": "value"}})
-	assert.Equal(t, bson.A{bson.D{{Key: FieldTenantID, Value: tenantID}, {Key: "key", Value: "value"}}}, res)
+	assert.Equal(t, bson.A{bson.D{{Key: "key", Value: "value"}, {Key: FieldTenantID, Value: tenantID}}}, res)
 }
 
 func TestDbFromContextEmptyContext(t *testing.T) {

--- a/store/v2/utils_test.go
+++ b/store/v2/utils_test.go
@@ -34,16 +34,16 @@ func TestWithTenantID(t *testing.T) {
 
 	// without tenant ID
 	res := WithTenantID(ctx, map[string]interface{}{"key": "value"})
-	assert.Equal(t, bson.D{{Key: "key", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: ""}, {Key: "key", Value: "value"}}, res)
 
 	res = WithTenantID(ctx, bson.M{"key": "value"})
-	assert.Equal(t, bson.D{{Key: "key", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: ""}, {Key: "key", Value: "value"}}, res)
 
 	res = WithTenantID(ctx, bson.D{{Key: "key", Value: "value"}})
-	assert.Equal(t, bson.D{{Key: "key", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: ""}, {Key: "key", Value: "value"}}, res)
 
 	res = WithTenantID(ctx, sample)
-	assert.Equal(t, bson.D{{Key: "attribute", Value: "value"}}, res)
+	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: ""}, {Key: "attribute", Value: "value"}}, res)
 
 	res = WithTenantID(ctx, "dummy-value")
 	assert.Equal(t, bson.D{}, res)
@@ -69,7 +69,7 @@ func TestWithTenantID(t *testing.T) {
 	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: tenantID}, {Key: "attribute", Value: "value"}}, res)
 
 	res = WithTenantID(ctx, "dummy-value")
-	assert.Equal(t, bson.D{{Key: FieldTenantID, Value: tenantID}}, res)
+	assert.Equal(t, bson.D{}, res)
 }
 
 func TestArrayWithTenantID(t *testing.T) {
@@ -77,7 +77,7 @@ func TestArrayWithTenantID(t *testing.T) {
 
 	// without tenant ID
 	res := ArrayWithTenantID(ctx, bson.A{bson.M{"key": "value"}})
-	assert.Equal(t, bson.A{bson.D{{Key: "key", Value: "value"}}}, res)
+	assert.Equal(t, bson.A{bson.D{{Key: FieldTenantID, Value: ""}, {Key: "key", Value: "value"}}}, res)
 
 	// with tenant ID
 	const tenantID = "bar"


### PR DESCRIPTION
Conditionally adding the tenant_id field prevents reuse of multi-key indexes on the tenant_id key.