### PR TITLE
Use existing mongo server for unit tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,3 +13,7 @@ include:
 stages:
   - test
   - publish
+
+test:unit:
+  variables:
+    TEST_MONGO_URL: "mongodb://mongo"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-golang-static.yml'
   - project: 'Northern.tech/Mender/mendertesting'
-    file: '.gitlab-ci-check-golang-unittests.yml'
+    file: '.gitlab-ci-check-golang-unittests-v2.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-commits-signoffs.yml'
   - project: 'Northern.tech/Mender/mendertesting'

--- a/mongo/testing/db_env.go
+++ b/mongo/testing/db_env.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package testing
+
+import (
+	"context"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type dbClientFromEnv mongo.Client
+
+// CTX is required for testing.DBTestRunner
+func (self *dbClientFromEnv) CTX() context.Context {
+	return context.TODO()
+}
+
+func (self *dbClientFromEnv) Client() *mongo.Client {
+	return (*mongo.Client)(self)
+}
+
+func (self *dbClientFromEnv) Wipe() {
+	client := self.Client()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	names, err := client.ListDatabaseNames(ctx, bson.D{})
+	if err != nil {
+		panic(err)
+	}
+	for _, name := range names {
+		switch name {
+		case "admin", "local", "config":
+		default:
+			err = client.
+				Database(name).
+				Drop(ctx)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+}

--- a/mongo/testing/db_env_test.go
+++ b/mongo/testing/db_env_test.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package testing
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestRunnerFromEnv(t *testing.T) {
+	if _, ok := os.LookupEnv("TEST_MONGO_URL"); !ok {
+		t.Skip("Test requires TEST_MONGO_URL to be set")
+	}
+
+	_ = WithDB(func(runner TestDBRunner) int {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		err := runner.Client().
+			Ping(ctx, nil)
+		if err != nil {
+			t.Errorf("failed to ping MongoDB server: %s", err)
+			t.Fail()
+		} else {
+			t.Log("YAY!")
+		}
+		return 0
+	})
+}


### PR DESCRIPTION
Introduce a new environment variable TEST_MONGO_URL which allows unit tests to use existing mongo server instead of installing mongod locally.