### PR TITLE
chore: Extend the ProtoMsg.Error schema with a status field

### DIFF
--- a/ws/protomsg.go
+++ b/ws/protomsg.go
@@ -102,6 +102,10 @@ type Error struct {
 	Error string `msgpack:"err" json:"error"`
 	// Close determines whether the session closed as a result of this error.
 	Close bool `msgpack:"close" json:"close"`
+	// Code is the error code associated with the error. Values in the
+	// range 400-599 carry the same semantic meaning as the HTTP equivalent.
+	// Please allocate new error codes starting from 1000 for custom error codes.
+	Code int `msgpack:"code,omitempty" json:"code,omitempty"`
 	// MessageProto is the protocol of the message that caused the error.
 	MessageProto ProtoType `msgpack:"msgproto,omitempty" json:"message_protocol,omitempty"`
 	// Type of message that raised the error


### PR DESCRIPTION
The status hint code is a necessary hint for the server to determine what status to return.