### PR TITLE
chore: Fix redis connection string error handling

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -133,6 +133,9 @@ func ClientFromConnectionString(
 			rdb = redis.NewClient(redisOpts)
 		}
 	}
+	if err != nil {
+		return nil, fmt.Errorf("redis: invalid connection string: %w", err)
+	}
 	_, err = rdb.
 		Ping(ctx).
 		Result()


### PR DESCRIPTION
The error when parsing the connection string is not caught and will lead to panic.