### PR TITLE
Squash response helper errors into the accesslog entry

### DIFF
--- a/accesslog/context.go
+++ b/accesslog/context.go
@@ -1,0 +1,104 @@
+// Copyright 2024 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package accesslog
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+const (
+	DefaultMaxErrors = 5
+)
+
+type AccessLogFormat string
+
+type LogContext interface {
+	PushError(err error) bool
+	SetField(key string, value interface{})
+}
+
+type logContext struct {
+	errors    []error
+	mu        sync.Mutex
+	maxErrors int
+	fields    map[string]interface{}
+}
+
+func (c *logContext) SetField(key string, value interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.fields == nil {
+		c.fields = make(map[string]interface{})
+	}
+	c.fields[key] = value
+}
+
+func (c *logContext) PushError(err error) bool {
+	if c.maxErrors > 0 {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if len(c.errors) > c.maxErrors {
+			return false
+		}
+	}
+	c.errors = append(c.errors, err)
+	return true
+}
+
+func (c *logContext) addFields(fields map[string]interface{}) {
+	if c == nil {
+		return
+	}
+	switch len(c.errors) {
+	case 0:
+	case 1:
+		if c.errors[0] != nil {
+			fields["error"] = c.errors[0].Error()
+		}
+	default:
+		var s strings.Builder
+		for i, err := range c.errors {
+			if err != nil {
+				s.WriteString(err.Error())
+				if i < len(c.errors)-1 {
+					s.WriteString("; ")
+				}
+			}
+		}
+		fields["error"] = s.String()
+	}
+	for key, value := range c.fields {
+		fields[key] = value
+	}
+}
+
+type logContextKey struct{}
+
+func withContext(ctx context.Context, c *logContext) context.Context {
+	return context.WithValue(ctx, logContextKey{}, c)
+}
+
+func fromContext(ctx context.Context) *logContext {
+	if c, ok := ctx.Value(logContextKey{}).(*logContext); ok && c != nil {
+		return c
+	}
+	return nil
+}
+
+func GetContext(ctx context.Context) LogContext {
+	return fromContext(ctx)
+}

--- a/accesslog/middleware_gin.go
+++ b/accesslog/middleware_gin.go
@@ -47,6 +47,10 @@ func (a AccessLogger) LogFunc(
 		"type":      c.Request.Proto,
 		"useragent": c.Request.UserAgent(),
 	}
+	lc := fromContext(ctx)
+	if lc != nil {
+		lc.addFields(logCtx)
+	}
 	if r := recover(); r != nil {
 		trace := collectTrace()
 		logCtx["trace"] = trace
@@ -111,6 +115,8 @@ func (a AccessLogger) LogFunc(
 func (a AccessLogger) Middleware(c *gin.Context) {
 	ctx := c.Request.Context()
 	startTime := time.Now()
+	ctx = withContext(ctx, &logContext{maxErrors: DefaultMaxErrors})
+	c.Request = c.Request.WithContext(ctx)
 	defer a.LogFunc(ctx, c, startTime)
 	c.Next()
 }

--- a/log/log.go
+++ b/log/log.go
@@ -212,12 +212,12 @@ func (hook ContextHook) Levels() []logrus.Level {
 	return logrus.AllLevels
 }
 
-func fmtCaller(frame runtime.Frame) string {
+func FmtCaller(caller runtime.Frame) string {
 	return fmt.Sprintf(
 		logFieldCallerFmt,
-		path.Base(frame.Function),
-		path.Base(frame.File),
-		frame.Line,
+		path.Base(caller.Function),
+		path.Base(caller.File),
+		caller.Line,
 	)
 }
 
@@ -240,7 +240,7 @@ func (hook ContextHook) Fire(entry *logrus.Entry) error {
 			}
 		}
 		if caller != nil {
-			entry.Data[logFieldCaller] = fmtCaller(*caller)
+			entry.Data[logFieldCaller] = FmtCaller(*caller)
 		}
 	}
 	return nil
@@ -258,7 +258,7 @@ func (l *Logger) WithCallerContext(skipParents int) *Logger {
 		Next()
 	if frame.Func != nil {
 		newEntry = &Logger{Entry: l.Dup()}
-		newEntry.Data[logFieldCaller] = fmtCaller(frame)
+		newEntry.Data[logFieldCaller] = FmtCaller(frame)
 	}
 	return newEntry
 }

--- a/rest_utils/response_helpers.go
+++ b/rest_utils/response_helpers.go
@@ -15,19 +15,32 @@ package rest_utils
 
 import (
 	"net/http"
+	"runtime"
 
 	"github.com/ant0ine/go-json-rest/rest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/mendersoftware/go-lib-micro/accesslog"
 	"github.com/mendersoftware/go-lib-micro/log"
 	"github.com/mendersoftware/go-lib-micro/requestid"
 )
 
+func getCalleeFrame(skip int) *runtime.Frame {
+	const calleeDepth = 2
+	var pc [1]uintptr
+	i := runtime.Callers(calleeDepth+skip, pc[:])
+	frame, _ := runtime.CallersFrames(pc[:i]).
+		Next()
+	if frame.Func != nil {
+		return &frame
+	}
+	return nil
+}
+
 // return selected http code + error message directly taken from error
 // log error
 func RestErrWithLog(w rest.ResponseWriter, r *rest.Request, l *log.Logger, e error, code int) {
-	l = l.WithCallerContext(1)
 	restErrWithLogMsg(w, r, l, e, code, "", logrus.ErrorLevel)
 }
 
@@ -35,28 +48,24 @@ func RestErrWithLog(w rest.ResponseWriter, r *rest.Request, l *log.Logger, e err
 // log full error
 func RestErrWithLogInternal(w rest.ResponseWriter, r *rest.Request, l *log.Logger, e error) {
 	msg := "internal error"
-	l = l.WithCallerContext(1)
 	restErrWithLogMsg(w, r, l, e, http.StatusInternalServerError, msg, logrus.ErrorLevel)
 }
 
 // return an error code with an overriden message (to avoid exposing the details)
 // log full error as debug
 func RestErrWithDebugMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger, e error, code int, msg string) {
-	l = l.WithCallerContext(1)
 	restErrWithLogMsg(w, r, l, e, code, msg, logrus.DebugLevel)
 }
 
 // return an error code with an overriden message (to avoid exposing the details)
 // log full error as info
 func RestErrWithInfoMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger, e error, code int, msg string) {
-	l = l.WithCallerContext(1)
 	restErrWithLogMsg(w, r, l, e, code, msg, logrus.InfoLevel)
 }
 
 // return an error code with an overriden message (to avoid exposing the details)
 // log full error as warning
 func RestErrWithWarningMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger, e error, code int, msg string) {
-	l = l.WithCallerContext(1)
 	restErrWithLogMsg(w, r, l, e, code, msg, logrus.WarnLevel)
 }
 
@@ -64,28 +73,24 @@ func RestErrWithWarningMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger
 // return an error code with an overriden message (to avoid exposing the details)
 // log full error as error
 func RestErrWithLogMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger, e error, code int, msg string) {
-	l = l.WithCallerContext(1)
 	restErrWithLogMsg(w, r, l, e, code, msg, logrus.ErrorLevel)
 }
 
 // return an error code with an overriden message (to avoid exposing the details)
 // log full error as error
 func RestErrWithErrorMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger, e error, code int, msg string) {
-	l = l.WithCallerContext(1)
 	restErrWithLogMsg(w, r, l, e, code, msg, logrus.ErrorLevel)
 }
 
 // return an error code with an overriden message (to avoid exposing the details)
 // log full error as fatal
 func RestErrWithFatalMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger, e error, code int, msg string) {
-	l = l.WithCallerContext(1)
 	restErrWithLogMsg(w, r, l, e, code, msg, logrus.FatalLevel)
 }
 
 // return an error code with an overriden message (to avoid exposing the details)
 // log full error as panic
 func RestErrWithPanicMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger, e error, code int, msg string) {
-	l = l.WithCallerContext(1)
 	restErrWithLogMsg(w, r, l, e, code, msg, logrus.PanicLevel)
 }
 
@@ -93,11 +98,22 @@ func RestErrWithPanicMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger, 
 // log full error with given log level
 func restErrWithLogMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger,
 	e error, code int, msg string, logLevel logrus.Level) {
-
 	if msg != "" {
-		e = errors.Wrap(e, msg)
+		e = errors.WithMessage(e, msg)
 	} else {
 		msg = e.Error()
+	}
+	var emitLog bool
+	if lc := accesslog.GetContext(r.Context()); lc != nil {
+		err := e
+		// Try push error to accesslog middleware.
+		f := getCalleeFrame(2)
+		if f != nil {
+			// Add the call frame to the error message:
+			// "<call frame>: <error message>"
+			err = errors.WithMessage(e, log.FmtCaller(*f))
+		}
+		emitLog = !lc.PushError(err)
 	}
 
 	w.WriteHeader(code)
@@ -108,18 +124,24 @@ func restErrWithLogMsg(w rest.ResponseWriter, r *rest.Request, l *log.Logger,
 	if err != nil {
 		panic(err)
 	}
-	switch logLevel {
-	case logrus.DebugLevel:
-		l.Debug(e.Error())
-	case logrus.InfoLevel:
-		l.Info(e.Error())
-	case logrus.WarnLevel:
-		l.Warn(e.Error())
-	case logrus.ErrorLevel:
-		l.Error(e.Error())
-	case logrus.FatalLevel:
-		l.Fatal(e.Error())
-	case logrus.PanicLevel:
-		l.Panic(e.Error())
+	if emitLog {
+		// Only emit a log entry if we failed to push the error to
+		// accessloger.
+		// Set the caller frame for the entry
+		l = l.WithCallerContext(2)
+		switch logLevel {
+		case logrus.DebugLevel:
+			l.Debug(e.Error())
+		case logrus.InfoLevel:
+			l.Info(e.Error())
+		case logrus.WarnLevel:
+			l.Warn(e.Error())
+		case logrus.ErrorLevel:
+			l.Error(e.Error())
+		case logrus.FatalLevel:
+			l.Fatal(e.Error())
+		case logrus.PanicLevel:
+			l.Panic(e.Error())
+		}
 	}
 }

--- a/rest_utils/response_helpers_test.go
+++ b/rest_utils/response_helpers_test.go
@@ -1,0 +1,180 @@
+// Copyright 2024 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package rest_utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ant0ine/go-json-rest/rest"
+	"github.com/mendersoftware/go-lib-micro/accesslog"
+	"github.com/mendersoftware/go-lib-micro/log"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type logCounter struct {
+	n int
+}
+
+func (logCounter) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (l *logCounter) Fire(*logrus.Entry) error {
+	l.n++
+	return nil
+}
+
+func TestResponseHelpers(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Name string
+		CTX  context.Context
+
+		HandlerFunc rest.HandlerFunc
+		NumEntries  int
+
+		Fields       []string
+		ExpectedBody string
+	}{{
+		Name: "internal",
+
+		NumEntries: 1,
+		HandlerFunc: func(w rest.ResponseWriter, r *rest.Request) {
+			RestErrWithLogInternal(w, r, log.NewEmpty(), errors.New("test error"))
+		},
+		Fields: []string{
+			`level=error`,
+			`error="(?P<callerFrame>rest_utils.TestResponseHelpers[^@]+` +
+				`@[^:]+:[0-9]+:) internal error: test error"`,
+		},
+		ExpectedBody: func() string {
+			b, _ := json.Marshal(ApiError{Err: "internal error"})
+			return string(b)
+		}(),
+	}, {
+		Name: "client error",
+
+		NumEntries: 1,
+		HandlerFunc: func(w rest.ResponseWriter, r *rest.Request) {
+			RestErrWithWarningMsg(w, r, log.NewEmpty(),
+				errors.New("test error"), http.StatusBadRequest, "bad request")
+		},
+		Fields: []string{
+			`level=warn`,
+			`error="(?P<callerFrame>rest_utils.TestResponseHelpers[^@]+` +
+				`@[^:]+:[0-9]+:) bad request: test error"`,
+		},
+		ExpectedBody: func() string {
+			b, _ := json.Marshal(ApiError{Err: "bad request"})
+			return string(b)
+		}(),
+	}, {
+		Name: "fallback to logger",
+
+		NumEntries: 2,
+		HandlerFunc: func(w rest.ResponseWriter, r *rest.Request) {
+			lc := accesslog.GetContext(r.Request.Context())
+			e := errors.New("test")
+			i := 0
+			for lc.PushError(e) && i < 10000 {
+				i++
+			}
+			if i >= 10000 {
+				// Guard against breaking the accesslog
+				t.Error("should not be able to push 10000 errors to accesslog")
+				t.FailNow()
+			}
+			RestErrWithWarningMsg(w, r, log.NewEmpty(),
+				errors.New("test error"), http.StatusBadRequest, "bad request")
+		},
+		Fields: []string{
+			`level=warn`,
+			`msg="bad request: test error"`,
+		},
+		ExpectedBody: func() string {
+			b, _ := json.Marshal(ApiError{Err: "bad request"})
+			return string(b)
+		}(),
+	}}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			app, err := rest.MakeRouter(rest.Get("/test", tc.HandlerFunc))
+			if err != nil {
+				t.Error(err)
+				t.FailNow()
+			}
+			counter := &logCounter{}
+			api := rest.NewApi()
+			var logBuf = bytes.NewBuffer(nil)
+			api.Use(rest.MiddlewareSimple(
+				func(h rest.HandlerFunc) rest.HandlerFunc {
+					logger := log.NewEmpty()
+					logger.Logger.SetLevel(logrus.DebugLevel)
+					logger.Logger.SetOutput(logBuf)
+					logger.Logger.SetFormatter(&logrus.TextFormatter{
+						DisableColors: true,
+						FullTimestamp: true,
+					})
+					logger.Logger.AddHook(counter)
+					return func(w rest.ResponseWriter, r *rest.Request) {
+						ctx := r.Request.Context()
+						ctx = log.WithContext(ctx, logger)
+						r.Request = r.Request.WithContext(ctx)
+						h(w, r)
+					}
+				}))
+			api.Use(&accesslog.AccessLogMiddleware{})
+			api.SetApp(app)
+			handler := api.MakeHandler()
+			w := httptest.NewRecorder()
+			ctx := context.Background()
+			if tc.CTX != nil {
+				ctx = tc.CTX
+			}
+			req, _ := http.NewRequestWithContext(
+				ctx,
+				http.MethodGet,
+				"http://localhost/test?foo=bar",
+				nil,
+			)
+			req.Header.Set("User-Agent", "tester")
+
+			handler.ServeHTTP(w, req)
+
+			logEntry := logBuf.String()
+			for _, field := range tc.Fields {
+				assert.Regexp(t, field, logEntry)
+			}
+			if tc.Fields == nil {
+				assert.Empty(t, logEntry)
+			}
+			if tc.ExpectedBody != "" {
+				if assert.NotNil(t, w.Body) {
+					assert.JSONEq(t, tc.ExpectedBody, w.Body.String())
+				}
+			}
+			assert.Equal(t, tc.NumEntries, counter.n)
+		})
+	}
+}


### PR DESCRIPTION
This change will improve debugging in many situations as the accesslog contains all the information to trace back the callee that emitted the error. It also improves the log volume emitted from our services as the response error helpers now enrich the accesslog context.