### PR TITLE
Redis connection string fix in K8s

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -90,6 +90,10 @@ func ClientFromConnectionString(
 			addrs = append(addrs, fmt.Sprintf("%s:%d", host, srv[i].Port))
 		}
 		redisurl.Host = strings.Join(addrs, ",")
+		// cleanup the scheme with one known to Redis
+		// to avoid: invalid URL scheme: tcp-redis+srv
+		redisurl.Scheme = "redis"
+
 	} else if scheme == "" {
 		redisurl.Scheme = "redis"
 	}


### PR DESCRIPTION
In k8s we're using the convinient connection scheme tcp-redis+srv that is needed to build a SRV connection string, but after constructing that, the scheme remains "tcp-redis+srv" and the redis connection fails. This fix force the "redis" scheme, after constructing the connection string.

Ticket: MEN-7035
Changelog: restore the right redis connection scheme