### PR TITLE
feat: Added query parameter to force cluster mode

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -125,7 +125,9 @@ func ClientFromConnectionString(
 		redisurl.Host = redisurl.Host[idx+1:]
 	}
 	var cluster bool
-	if _, ok := q["addr"]; ok {
+	if _, ok := q["cluster"]; ok {
+		cluster, _ = strconv.ParseBool(q.Get("cluster"))
+	} else if _, ok := q["addr"]; ok {
 		cluster = true
 	}
 	if cluster {


### PR DESCRIPTION
The Redis client can resolve dynamically resolve the cluster nodes by connecting to a single cluster node.