### PR TITLE
feat: allocate ProtoTypePortForwardV2

### DIFF
--- a/ws/protomsg.go
+++ b/ws/protomsg.go
@@ -33,6 +33,8 @@ const (
 	// ProtoTypeMenderClient is used for communication with the Mender client.
 	ProtoTypeMenderClient
 
+	ProtoTypePortForwardV2 = ProtoTypePortForward + 0x100
+
 	// ProtoTypeControl is a reserved proto type for session control messages.
 	ProtoTypeControl ProtoType = 0xFFFF
 )


### PR DESCRIPTION
The new port forwarding drops the message acknowledgement (requires mender-server > 4.1).